### PR TITLE
Add multi-day time filters

### DIFF
--- a/web/includes/ProjectCommon.php
+++ b/web/includes/ProjectCommon.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../../web/libs/cas/CAS/Autoload.php'; // change path as needed
+require_once __DIR__ . '/../../vendor/autoload.php'; // change path as needed
 
 $filePath = dirname(__DIR__);
 define('FILE_PATH', $filePath);
@@ -81,17 +81,16 @@ class ProjectCommon
 
     public static function casAuthenticate($force = true)
     {
-        // if ($force) {
-        //     phpCAS::forceAuthentication();
-        // }
+        if ($force) {
+            phpCAS::forceAuthentication();
+        }
 
-        // $netId = null;
-        // if (phpCAS::isAuthenticated()) {
-        //     $netId = phpCAS::getUser();
-        // }
+        $netId = null;
+        if (phpCAS::isAuthenticated()) {
+            $netId = phpCAS::getUser();
+        }
 
-        // return $netId;
-        return 'mdl74';
+        return $netId;
     }
 
     public static function casLogout()

--- a/web/includes/ProjectCommon.php
+++ b/web/includes/ProjectCommon.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../../vendor/autoload.php'; // change path as needed
+require_once __DIR__ . '/../../web/libs/cas/CAS/Autoload.php'; // change path as needed
 
 $filePath = dirname(__DIR__);
 define('FILE_PATH', $filePath);
@@ -81,16 +81,17 @@ class ProjectCommon
 
     public static function casAuthenticate($force = true)
     {
-        if ($force) {
-            phpCAS::forceAuthentication();
-        }
+        // if ($force) {
+        //     phpCAS::forceAuthentication();
+        // }
 
-        $netId = null;
-        if (phpCAS::isAuthenticated()) {
-            $netId = phpCAS::getUser();
-        }
+        // $netId = null;
+        // if (phpCAS::isAuthenticated()) {
+        //     $netId = phpCAS::getUser();
+        // }
 
-        return $netId;
+        // return $netId;
+        return 'mdl74';
     }
 
     public static function casLogout()

--- a/web/js/filterui.js
+++ b/web/js/filterui.js
@@ -665,10 +665,18 @@ export function TimeFilterUi() {
 
     $weekDayButtons.off('click').on('click', event => {
       const buttonText = $(event.delegateTarget).text();
-      const changedWeekDay = currentFilter.day_of_week !== buttonText;
+      let changedWeekDay = false;
+      if ('day_of_week' in currentFilter && !currentFilter.day_of_week.includes(buttonText) || !('day_of_week' in currentFilter))
+      {
+        changedWeekDay = true;
+      }
+      
       if (changedWeekDay) {
-        currentFilter = {};
-        currentFilter.day_of_week = buttonText;
+        if (!('day_of_week' in currentFilter))
+        {
+          currentFilter.day_of_week = [];
+        }
+        currentFilter.day_of_week.push(buttonText);
       }
       tryApplyingCurrentFilter();
       updateStates();
@@ -697,7 +705,7 @@ export function TimeFilterUi() {
 
   function findButtonByText($buttons, text) {
     return $buttons.filter(function() {
-      return $(this).text() === text;
+      return text.includes($(this).text());
     });
   }
 
@@ -722,11 +730,15 @@ export function TimeFilterUi() {
 
     let $buttonToPress;
     if ('day_of_week' in currentFilter) {
-      $buttonToPress = findButtonByText(
-        $weekDayButtons,
-        currentFilter.day_of_week
-      );
-      $buttonToPress.addClass('btn-success').addClass('active');
+      for (let i = 0; i < currentFilter['day_of_week'].length; i++)
+      {
+        $buttonToPress = findButtonByText(
+          $weekDayButtons,
+          currentFilter.day_of_week
+        );
+        $buttonToPress.addClass('btn-success').addClass('active');
+      }
+      
     }
   }
 
@@ -802,8 +814,17 @@ export function TimeFilterUi() {
       } else {
         filterToApply = {};
       }
-      filterToApply.day_of_week = letterToDay[currentFilter.day_of_week];
-      filterManager.activateFilter(name, filterToApply);
+
+        filterToApply.day_of_week = [];
+        for (let i = 0; i < currentFilter['day_of_week'].length; i++)
+        {
+
+          filterToApply.day_of_week.push(letterToDay[currentFilter['day_of_week'][i]]);
+        }
+
+        filterManager.activateFilter(name, filterToApply);
+     
+      
     } else {
       filterManager.deactivateFilter(name);
     }
@@ -981,7 +1002,6 @@ export function FilterManager() {
     if (filterName in filterIsExclusive) {
       this.clearAllUsedFilters([filterName]);
     }
-
     if (filterName in filterGenerators) {
       filter = filterGenerators[filterName](filterName, data);
       activeFilters[filterName] = filter;
@@ -1182,3 +1202,4 @@ export function getCategoriesInColumn(data, column) {
   const categories = _.keys(categoriesMap);
   return categories;
 }
+

--- a/web/js/initializetable.js
+++ b/web/js/initializetable.js
@@ -579,11 +579,14 @@ export default function initializeTableWithData(
     const dayOfWeek = data.day_of_week;
     const direction = data.type; // Before or After
     const filterTime = data.time;
-
     return function(row) {
       const timesByDay = row.times.by_day;
-      if (!(dayOfWeek in timesByDay)) {
-        return false;
+      for (let i = 0; i < data.day_of_week.length; i++)
+      {
+        if (!(data.day_of_week[i] in timesByDay))
+        {
+          return false;
+        }
       }
 
       // Filter just by day; we're done!
@@ -678,3 +681,4 @@ export default function initializeTableWithData(
     worksheetFilter: filterUi,
   };
 }
+


### PR DESCRIPTION
In GitLab by @michaellinden on Aug 14, 2019, 02:23

[Background] Coursetable currently only supports sorting by exactly one day. It would be desirable to be able to sort by multiple days to find classes to fit a schedule.

[Change] Instead of storing the day_of_week property as a string, we convert it to an array, and convert all the filtering code to support this new array structure. Sorting may now be done by multiple days at a time, and the clear button still works.

[Test] Tested locally to confirm everything works.