### PR TITLE
Fix bug in worksheet actions

### DIFF
--- a/web/WorksheetActions.php
+++ b/web/WorksheetActions.php
@@ -172,7 +172,6 @@ $log = ProjectCommon::createLog('WorksheetAddRemove');
 $mysqli = ProjectCommon::createYaleAdvancedOciMysqli();
 
 $netId = ProjectCommon::casAuthenticate(false);
-$ociId = (string) $_GET['ociId'];
 $action = (string) $_GET['action'];
 $season = $_GET['season'];
 
@@ -181,8 +180,10 @@ $success = checkArguments($netId, $ociId, $action, $season)
 
 if ($success) {
     if ($action === 'add') {
+        $ociId = (string) $_GET['ociId'];
         addToWorksheet($netId, $ociId, $season);
     } elseif ($action === 'remove') {
+        $ociId = (string) $_GET['ociId'];
         removeFromWorksheet($netId, $ociId, $season);
     } else {
         retrieveWorksheetOciIdsJson($netId, $season);


### PR DESCRIPTION
Resolves the following error message:
`2019/12/03 14:55:35 [error] 1346#1346: *284747 FastCGI sent in stderr: "PHP message: PHP Notice:  Undefined index: ociId in /home/web/app/web/WorksheetActions.php on line 175" while reading response header from upstream, client: <clip>, server: coursetable.com, request: "GET /WorksheetActions.php?action=get&season=202001 HTTP/1.1", upstream: "fastcgi://unix:/run/php/php7.2-fpm.sock:", host: "coursetable.com", referrer: "https://coursetable.com/Table/202001"`