### PR TITLE
Keep the same hook order in MeDropdown

### DIFF
--- a/frontend/src/components/MeDropdown.js
+++ b/frontend/src/components/MeDropdown.js
@@ -27,14 +27,11 @@ function MeDropdown({ profile_expanded, setIsComponentVisible, isLoggedIn }) {
   // Season to export classes from
   const CUR_SEASON = '202003';
 
-  // Make sure worksheet is loaded
-  if (user.worksheet) {
-    // Initialize the lazy query function
-    var [fetchWorksheetListings, { data }] = FetchWorksheetLazy(
-      user.worksheet,
-      CUR_SEASON
-    );
-  }
+  // Initialize the lazy query function
+  const [fetchWorksheetListings, { data }] = FetchWorksheetLazy(
+    user.worksheet,
+    CUR_SEASON
+  );
 
   // Handle 'export worksheet' button clikc
   const handleExportClick = () => {

--- a/frontend/src/queries/GetWorksheetListings.js
+++ b/frontend/src/queries/GetWorksheetListings.js
@@ -67,10 +67,9 @@ export const FetchWorksheet = (worksheet) => {
 
 // Lazy search query used in MeDropdown.js
 export const FetchWorksheetLazy = (worksheet, season_code) => {
-  let filtered_worksheet = [];
   // Get worksheet listings for this season
-  worksheet.forEach((course) => {
-    if (course[0] === season_code) filtered_worksheet.push(course);
+  const filtered_worksheet = (worksheet || []).filter((course) => {
+    return course[0] === season_code;
   });
   // Build gql query
   const builtQuery = buildQuery(filtered_worksheet);


### PR DESCRIPTION
React crashes if the order/number of hooks changes after the first render