### PR TITLE
Fix bug: prof ratings missing from course modal

### DIFF
--- a/frontend/src/queries/QueryStrings.js
+++ b/frontend/src/queries/QueryStrings.js
@@ -89,6 +89,7 @@ export const SEARCH_AVERAGE_ACROSS_SEASONS = gql`
       }
     ) {
       professor_names
+      professor_info
       season_code
       all_course_codes
       section


### PR DESCRIPTION
-add back professor_info to query (accidentally deleted when updating modal headers)