### PR TITLE
Static catalog

### DIFF
--- a/api/config/constants.js
+++ b/api/config/constants.js
@@ -14,4 +14,7 @@ export const NUM_CHALLENGE_COURSES = 3; // number of courses to select for the c
 export const CHALLENGE_SEASON = '201903'; // season to select the challenge from
 export const MAX_CHALLENGE_REQUESTS = 100; // maximum number of allowed challenge tries
 
-export const FERRY_SECRET = process.env.FERRY_SECRET || die('ferry secret');
+export const FERRY_SECRET =
+  process.env.FERRY_SECRET !== undefined
+    ? process.env.FERRY_SECRET
+    : die('ferry secret');

--- a/api/config/constants.js
+++ b/api/config/constants.js
@@ -1,11 +1,17 @@
-export const GRAPHQL_ENDPOINT = process.env.GRAPHQL_ENDPOINT;
+const die = (err) => {
+  throw new Error(err);
+};
+
+export const GRAPHQL_ENDPOINT =
+  process.env.GRAPHQL_ENDPOINT || die('graphql endpoint');
 export const PORT = 4096;
 
 export const CHALLENGE_ALGORITHM = 'aes-256-ctr';
 export const CHALLENGE_PASSWORD =
-  process.env.CHALLENGE_PASSWORD || 'thisisapassword';
+  process.env.CHALLENGE_PASSWORD || die('challenge password');
 
 export const NUM_CHALLENGE_COURSES = 3; // number of courses to select for the challenge
 export const CHALLENGE_SEASON = '201903'; // season to select the challenge from
 export const MAX_CHALLENGE_REQUESTS = 100; // maximum number of allowed challenge tries
-export const FERRY_SECRET = process.env.FERRY_SECRET;
+
+export const FERRY_SECRET = process.env.FERRY_SECRET || die('ferry secret');

--- a/api/config/constants.js
+++ b/api/config/constants.js
@@ -8,3 +8,4 @@ export const CHALLENGE_PASSWORD =
 export const NUM_CHALLENGE_COURSES = 3; // number of courses to select for the challenge
 export const CHALLENGE_SEASON = '201903'; // season to select the challenge from
 export const MAX_CHALLENGE_REQUESTS = 100; // maximum number of allowed challenge tries
+export const FERRY_SECRET = process.env.FERRY_SECRET;

--- a/api/controllers/catalog.controllers.js
+++ b/api/controllers/catalog.controllers.js
@@ -1,0 +1,24 @@
+import graphqurl from 'graphqurl';
+const { query } = graphqurl;
+
+import { GRAPHQL_ENDPOINT } from '../config/constants.js';
+
+import {
+  listSeasonsQuery,
+  catalogBySeasonQuery,
+} from '../queries/catalog.queries.js';
+
+export const refreshCatalog = (req, res, next) => {
+  query({
+    query: listSeasonsQuery,
+    endpoint: GRAPHQL_ENDPOINT,
+  })
+    .then((seasons) => {
+      return res.json(seasons);
+    })
+    .catch((err) => {
+      return res.status(500).json({
+        error: err,
+      });
+    });
+};

--- a/api/controllers/catalog.controllers.js
+++ b/api/controllers/catalog.controllers.js
@@ -31,13 +31,16 @@ export const verifyHeaders = (req, res, next) => {
  * @prop next - express next object
  */
 export const refreshCatalog = (req, res, next) => {
-  fetchCatalog(true)
+  // always overwrite when callec
+  const overwrite = true;
+  fetchCatalog(overwrite)
     .then(() => {
       return res.status(200).json({
         status: 'OK',
       });
     })
     .catch((err) => {
+      console.error(err);
       return res.status(500).json(err);
     });
 };

--- a/api/controllers/catalog.controllers.js
+++ b/api/controllers/catalog.controllers.js
@@ -30,10 +30,14 @@ export const verifyHeaders = (req, res, next) => {
  * @prop res - express response object
  * @prop next - express next object
  */
-export const refreshCatalog = async (req, res, next) => {
-  await fetchCatalog();
-
-  return res.status(200).json({
-    status: 'OK',
-  });
+export const refreshCatalog = (req, res, next) => {
+  fetchCatalog(true)
+    .then(() => {
+      return res.status(200).json({
+        status: 'OK',
+      });
+    })
+    .catch((err) => {
+      return res.status(500).json(err);
+    });
 };

--- a/api/controllers/catalog.controllers.js
+++ b/api/controllers/catalog.controllers.js
@@ -3,6 +3,8 @@ const { query } = graphqurl;
 
 import { GRAPHQL_ENDPOINT } from '../config/constants.js';
 
+import { toJSON } from '../utils.js';
+
 import {
   listSeasonsQuery,
   catalogBySeasonQuery,
@@ -14,6 +16,11 @@ export const refreshCatalog = (req, res, next) => {
     endpoint: GRAPHQL_ENDPOINT,
   })
     .then((seasons) => {
+      // note that this directory is relative
+      // to where the function is called
+      // (i.e. /api)
+      toJSON('./static/seasons.json', seasons);
+
       return res.json(seasons);
     })
     .catch((err) => {

--- a/api/controllers/catalog.controllers.js
+++ b/api/controllers/catalog.controllers.js
@@ -19,7 +19,8 @@ export const refreshCatalog = (req, res, next) => {
       // note that this directory is relative
       // to where the function is called
       // (i.e. /api)
-      toJSON('./static/seasons.json', seasons);
+      console.log(seasons);
+      toJSON('./static/seasons.json', seasons.data.seasons);
 
       return res.json(seasons);
     })

--- a/api/controllers/catalog.controllers.js
+++ b/api/controllers/catalog.controllers.js
@@ -14,7 +14,7 @@ export const verifyHeaders = (req, res, next) => {
   const authd = req.header('x-ferry-secret'); // if user is logged in
 
   // require NetID authentication
-  if (authd !== FERRY_SECRET) {
+  if (FERRY_SECRET !== '' && authd !== FERRY_SECRET) {
     return res.status(401).json({
       error: 'NOT_AUTHENTICATED',
     });

--- a/api/controllers/challenge.controllers.js
+++ b/api/controllers/challenge.controllers.js
@@ -18,28 +18,6 @@ import { encrypt, decrypt, getRandomInt } from '../utils.js';
 import Student from '../models/student.models.js';
 
 /**
- * Middleware to verify request headers
- *
- * @prop req - express request object
- * @prop res - express response object
- * @prop next - express next object
- */
-export const verifyHeaders = (req, res, next) => {
-  // get authentication headers
-  const netid = req.header('x-coursetable-netid'); // user's NetID
-  const authd = req.header('x-coursetable-authd'); // if user is logged in
-
-  // require NetID authentication
-  if (authd !== 'true' || !netid) {
-    return res.status(401).json({
-      error: 'NOT_AUTHENTICATED',
-    });
-  }
-
-  next();
-};
-
-/**
  * Generate a challenge object given a query response.
  * Used by the requestChallenge controller.
  *

--- a/api/package.json
+++ b/api/package.json
@@ -2,6 +2,11 @@
   "scripts": {
     "start": "nodemon server.js"
   },
+  "nodemonConfig": {
+    "ignore": [
+      "static/*"
+    ]
+  },
   "dependencies": {
     "axios": "^0.20.0",
     "express": "^4.17.1",

--- a/api/queries/catalog.queries.js
+++ b/api/queries/catalog.queries.js
@@ -1,0 +1,43 @@
+import gql from 'graphql-tag';
+
+// query for getting catalog data by season
+export const listSeasonsQuery = gql`
+  query listSeasons($season: [String!]) {
+    seasons {
+      season_code
+      term
+      year
+    }
+  }
+`;
+
+// query for getting catalog data by season
+export const catalogBySeasonQuery = gql`
+  query catalogBySeason($season: String!) {
+    computed_listing_info(where: { season_code: { _eq: $season } }) {
+      listing_id
+      title
+      description
+      all_course_codes
+      professor_names
+      average_rating
+      average_workload
+      average_professor
+      times_summary
+      times_by_day
+      locations_summary
+      skills
+      areas
+      credits
+      course_code
+      school
+      requirements
+      season_code
+      extra_info
+      syllabus_url
+      enrollment
+      section
+      crn
+    }
+  }
+`;

--- a/api/queries/catalog.queries.js
+++ b/api/queries/catalog.queries.js
@@ -23,6 +23,7 @@ export const catalogBySeasonQuery = gql`
       average_rating
       average_workload
       average_professor
+      flag_info
       times_summary
       times_by_day
       locations_summary

--- a/api/routes/catalog.routes.js
+++ b/api/routes/catalog.routes.js
@@ -1,5 +1,8 @@
-import { refreshCatalog } from '../controllers/catalog.controllers.js';
+import {
+  verifyHeaders,
+  refreshCatalog,
+} from '../controllers/catalog.controllers.js';
 
 export default (app) => {
-  app.get('/api/catalog/refresh', refreshCatalog);
+  app.get('/api/catalog/refresh', verifyHeaders, refreshCatalog);
 };

--- a/api/routes/catalog.routes.js
+++ b/api/routes/catalog.routes.js
@@ -1,0 +1,5 @@
+import { refreshCatalog } from '../controllers/catalog.controllers.js';
+
+export default (app) => {
+  app.get('/api/catalog/refresh', refreshCatalog);
+};

--- a/api/routes/challenge.routes.js
+++ b/api/routes/challenge.routes.js
@@ -1,10 +1,11 @@
 import {
-  verifyHeaders,
   requestChallenge,
   verifyChallenge,
 } from '../controllers/challenge.controllers.js';
 
+import { verifyNetID } from '../utils.js';
+
 export default (app) => {
-  app.get('/api/challenge/request', verifyHeaders, requestChallenge);
+  app.get('/api/challenge/request', verifyNetID, requestChallenge);
   app.post('/api/challenge/verify', verifyChallenge);
 };

--- a/api/server.js
+++ b/api/server.js
@@ -10,6 +10,8 @@ import { PORT, FERRY_SECRET } from './config/constants.js';
 import challenge from './routes/challenge.routes.js';
 import catalog from './routes/catalog.routes.js';
 
+import { verifyNetID } from './utils.js';
+
 // import catalog fetch function (same as /api/catalog/refresh)
 import { fetchCatalog } from './utils.js';
 
@@ -23,7 +25,11 @@ app.use(morgan('tiny'));
 challenge(app);
 catalog(app);
 
-app.use('/api/static', express.static(path.join(path.resolve(), 'static')));
+app.use(
+  '/api/static',
+  verifyNetID,
+  express.static(path.join(path.resolve(), 'static'))
+);
 
 console.log('Updating static catalog');
 

--- a/api/server.js
+++ b/api/server.js
@@ -26,7 +26,10 @@ catalog(app);
 app.use('/api/static', express.static(path.join(path.resolve(), 'static')));
 
 console.log('Updating static catalog');
-fetchCatalog().then(() => {
+
+const overwriteCatalog = process.env.OVERWRITE_CATALOG || false;
+
+fetchCatalog(overwriteCatalog).then(() => {
   app.listen(PORT, () => {
     console.log(`Express API listening at http://localhost:${PORT}`);
   });

--- a/api/server.js
+++ b/api/server.js
@@ -6,6 +6,7 @@ import { PORT } from './config/constants.js';
 
 // import routes
 import challenge from './routes/challenge.routes.js';
+import catalog from './routes/catalog.routes.js';
 
 const app = express();
 // Enable url-encoding
@@ -15,7 +16,8 @@ app.use(morgan('tiny'));
 
 // apply routes
 challenge(app);
+catalog(app);
 
 app.listen(PORT, () => {
-  console.log(`Challenge API listening at http://localhost:${PORT}`);
+  console.log(`Express API listening at http://localhost:${PORT}`);
 });

--- a/api/server.js
+++ b/api/server.js
@@ -1,13 +1,17 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import morgan from 'morgan';
+import axios from 'axios';
 import path from 'path';
 
-import { PORT } from './config/constants.js';
+import { PORT, FERRY_SECRET } from './config/constants.js';
 
 // import routes
 import challenge from './routes/challenge.routes.js';
 import catalog from './routes/catalog.routes.js';
+
+// import catalog fetch function (same as /api/catalog/refresh)
+import { fetchCatalog } from './utils.js';
 
 const app = express();
 // Enable url-encoding
@@ -21,6 +25,9 @@ catalog(app);
 
 app.use('/api/static', express.static(path.join(path.resolve(), 'static')));
 
-app.listen(PORT, () => {
-  console.log(`Express API listening at http://localhost:${PORT}`);
+console.log('Updating static catalog');
+fetchCatalog().then(() => {
+  app.listen(PORT, () => {
+    console.log(`Express API listening at http://localhost:${PORT}`);
+  });
 });

--- a/api/server.js
+++ b/api/server.js
@@ -25,6 +25,7 @@ app.use(morgan('tiny'));
 challenge(app);
 catalog(app);
 
+// Mount static files route and require NetID authentication
 app.use(
   '/api/static',
   verifyNetID,

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import morgan from 'morgan';
+import path from 'path';
 
 import { PORT } from './config/constants.js';
 
@@ -17,6 +18,8 @@ app.use(morgan('tiny'));
 // apply routes
 challenge(app);
 catalog(app);
+
+app.use('/static', express.static(path.join(path.resolve(), 'static')));
 
 app.listen(PORT, () => {
   console.log(`Express API listening at http://localhost:${PORT}`);

--- a/api/server.js
+++ b/api/server.js
@@ -19,7 +19,7 @@ app.use(morgan('tiny'));
 challenge(app);
 catalog(app);
 
-app.use('/static', express.static(path.join(path.resolve(), 'static')));
+app.use('/api/static', express.static(path.join(path.resolve(), 'static')));
 
 app.listen(PORT, () => {
   console.log(`Express API listening at http://localhost:${PORT}`);

--- a/api/static/.gitignore
+++ b/api/static/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/api/static/.gitignore
+++ b/api/static/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!catalogs/.gitignore

--- a/api/utils.js
+++ b/api/utils.js
@@ -138,5 +138,5 @@ export async function fetchCatalog(overwrite) {
     }
   );
 
-  return Promise.all(processSeasons);
+  return Promise.allSettled(processSeasons);
 }

--- a/api/utils.js
+++ b/api/utils.js
@@ -54,6 +54,28 @@ export function getRandomInt(max) {
 }
 
 /**
+ * Middleware to verify request headers
+ *
+ * @prop req - express request object
+ * @prop res - express response object
+ * @prop next - express next object
+ */
+export const verifyNetID = (req, res, next) => {
+  // get authentication headers
+  const netid = req.header('x-coursetable-netid'); // user's NetID
+  const authd = req.header('x-coursetable-authd'); // if user is logged in
+
+  // require NetID authentication
+  if (authd !== 'true' || !netid) {
+    return res.status(401).json({
+      error: 'NOT_AUTHENTICATED',
+    });
+  }
+
+  next();
+};
+
+/**
  * Get static catalogs for each season from Hasura,
  * @prop overwrite - whether or not to skip existing catalogs.
  */

--- a/api/utils.js
+++ b/api/utils.js
@@ -88,6 +88,7 @@ export async function fetchCatalog(overwrite) {
       endpoint: GRAPHQL_ENDPOINT,
     });
   } catch (err) {
+    console.error(err);
     throw Error(err);
   }
 
@@ -119,18 +120,18 @@ export async function fetchCatalog(overwrite) {
           },
         });
       } catch (err) {
-        console.log(err);
+        console.error(err);
         throw err;
       }
-
-      console.log(
-        `Fetched season ${season_code}: n=${catalog.data.computed_listing_info.length}`
-      );
 
       if (catalog.data.computed_listing_info) {
         fs.writeFileSync(
           output_path,
           JSON.stringify(catalog.data.computed_listing_info)
+        );
+
+        console.log(
+          `Fetched season ${season_code}: n=${catalog.data.computed_listing_info.length}`
         );
         return;
       }

--- a/api/utils.js
+++ b/api/utils.js
@@ -72,6 +72,13 @@ export async function fetchCatalog(overwrite) {
 
   const processSeasons = await seasons.data.seasons.map(
     async ({ season_code }) => {
+      const output_path = `./static/catalogs/${season_code}.json`;
+
+      if (!overwrite && fs.existsSync(output_path)) {
+        console.log(`Catalog for ${season_code} exists, skipping`);
+        return;
+      }
+
       const catalog = await query({
         query: catalogBySeasonQuery,
         endpoint: GRAPHQL_ENDPOINT,
@@ -85,20 +92,13 @@ export async function fetchCatalog(overwrite) {
       );
 
       fs.writeFileSync(
-        `./static/catalogs/${season_code}.json`,
+        output_path,
         JSON.stringify(catalog.data.computed_listing_info)
       );
 
-      return [catalog, season_code];
+      return;
     }
   );
 
   const catalogs = await Promise.all(processSeasons);
-
-  // catalogs.map(([catalog, season_code]) => {
-  //   fs.writeFileSync(
-  //     `./static/catalogs/${season_code}.json`,
-  //     JSON.stringify(catalog.data.computed_listing_info)
-  //   );
-  // });
 }

--- a/api/utils.js
+++ b/api/utils.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import jsonfile from 'jsonfile';
 
 import { CHALLENGE_ALGORITHM, CHALLENGE_PASSWORD } from './config/constants.js';
 
@@ -38,4 +39,17 @@ export function decrypt(text, salt) {
  */
 export function getRandomInt(max) {
   return Math.floor(Math.random() * Math.floor(max));
+}
+
+const JSON_FORMAT = { spaces: 4, EOL: '\n' };
+
+/**
+ * Wrapper for exporting an object to JSON.
+ * @param {String} path
+ * @param {Object} obj
+ */
+export function toJSON(path, obj) {
+  jsonfile.writeFile(path, obj, JSON_FORMAT, function (err) {
+    if (err) console.error(err);
+  });
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       MYSQL_USER: root
       MYSQL_PASSWORD: GoCourseTable
       MYSQL_DB: yaleplus
+      CHALLENGE_PASSWORD: thisisapassword2
+      FERRY_SECRET: foobar
 
   frontend:
     image: node:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       MYSQL_PASSWORD: GoCourseTable
       MYSQL_DB: yaleplus
       CHALLENGE_PASSWORD: thisisapassword2
-      FERRY_SECRET: foobar
+      FERRY_SECRET: '' # we want this empty in development so no auth is required to refresh
 
   frontend:
     image: node:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:thisisapassword@coursetable.com:5432/postgres
       HASURA_GRAPHQL_ENABLE_CONSOLE: 'true' # set to "false" to disable console
-      HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      # HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       ## uncomment next line to set an admin secret
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:thisisapassword@coursetable.com:5432/postgres
       HASURA_GRAPHQL_ENABLE_CONSOLE: 'true' # set to "false" to disable console
-      # HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       ## uncomment next line to set an admin secret
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
 

--- a/docker/prod-compose.yml
+++ b/docker/prod-compose.yml
@@ -58,6 +58,8 @@ services:
       MYSQL_USER: ${MYSQL_USERNAME?username}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD?password}
       MYSQL_DB: yaleplus
+      CHALLENGE_PASSWORD: ${CHALLENGE_ENC_PASSWORD?challenge password}
+      FERRY_SECRET: ${FERRY_RELOAD_SECRET?ferry reload secret}
     networks:
       - mysql_default
       - default


### PR DESCRIPTION
- Adds `/api/static` endpoint for accessing static files (NetID auth required):
   - `/api/static/seasons.json`: list of all available seasons
   - `/api/static/catalogs/{season}.json`: catalog per season
- Fetches and populates static files on API server start (set `OVERWRITE_CATALOG` environment parameter to update each catalog file, otherwise existing catalogs are skipped)
- Adds `/api/catalog/refresh` endpoint to refresh the catalog remotely. Can be called without authentication in development, otherwise set `FERRY_SECRET` in environment and specify `x-ferry-secret` header when calling.