### PR TITLE
Fix sortby FB friends bug

### DIFF
--- a/frontend/src/utilities.js
+++ b/frontend/src/utilities.js
@@ -279,7 +279,12 @@ export const useSessionStorageState = (key, default_value) => {
 const helperSort = (listing, key, num_fb) => {
   // Sorting by fb friends
   if (key === 'fb') {
-    return num_fb[listing.season_code + listing.crn];
+    // Concatenate season code and crn to form key
+    const fb_key = listing.season_code + listing.crn;
+    // No friends. return null
+    if (!num_fb[fb_key]) return null;
+    // Has friends. return number of friends
+    return num_fb[fb_key].length;
   }
   // Sorting by course rating
   else if (key === 'average_rating') {


### PR DESCRIPTION
-Sort by number of FB friends instead of their names

Can't rlly test this cuz I only have 1 other account, but it should work