### PR TITLE
Fix search form bugs

### DIFF
--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -94,11 +94,8 @@ function Search() {
   const [ordering, setOrdering] = useSessionStorageState('ordering', {
     course_code: 'asc',
   });
-  // State to reset sortby select
-  const [reset_sortby, setResetSortby] = useSessionStorageState(
-    'reset_sortby',
-    0
-  );
+  // State to reset sortby dropdown and rating sliders
+  const [reset_key, setResetKey] = useState(0);
 
   // Show the modal for the course that was clicked
   const showModal = useCallback(
@@ -524,7 +521,7 @@ function Search() {
 
     setSSObject('select_sortby', sortbyOptions[0]);
     setSSObject('sort_order', 'asc');
-    setResetSortby(reset_sortby + 1);
+    setResetKey(reset_key + 1);
   };
 
   // check if the search form is too tall
@@ -647,10 +644,7 @@ function Search() {
               </Row>
 
               <Row className="mx-auto py-0 px-4">
-                <SortByReactSelect
-                  setOrdering={setOrdering}
-                  key={reset_sortby}
-                />
+                <SortByReactSelect setOrdering={setOrdering} key={reset_key} />
               </Row>
               <StyledHr />
               <Row className={`mx-auto py-0 px-4 ${Styles.multi_selects}`}>
@@ -740,6 +734,7 @@ function Search() {
                       min={1}
                       max={5}
                       step={0.1}
+                      key={reset_key}
                       defaultValue={ratingBounds}
                       // debounce the slider state update
                       // to make it smoother
@@ -761,6 +756,7 @@ function Search() {
                       min={1}
                       max={5}
                       step={0.1}
+                      key={reset_key}
                       defaultValue={workloadBounds}
                       // debounce the slider state update
                       // to make it smoother

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -85,14 +85,7 @@ function Search() {
   const searchTextInput = useRef(null);
   const [searchText, setSearchText] = useSessionStorageState('searchText', '');
   // Is the search form  collapsed?
-  const [collapsed_form, setCollapsedForm] = useSessionStorageState(
-    'collapsed_form',
-    false
-  );
-  // useEffect(() => {
-  //   if (width < 1200 && !collapsed_form) setCollapsedForm(true);
-  //   if (width > 1200 && collapsed_form) setCollapsedForm(false);
-  // }, [width]);
+  const [collapsed_form, setCollapsedForm] = useState(false);
 
   // State that determines if a course modal needs to be displayed and which course to display
   const [course_modal, setCourseModal] = useState([false, '']);

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -28,7 +28,7 @@ import { useWindowDimensions } from '../components/WindowDimensionsProvider';
 import { useCourseData, useFerry } from '../components/FerryProvider';
 import CustomSelect from '../components/CustomSelect';
 import SortByReactSelect from '../components/SortByReactSelect';
-import { getNumFB, sortCourses } from '../utilities';
+import { getNumFB, getOverallRatings, sortCourses } from '../utilities';
 import { sortbyOptions } from '../queries/Constants';
 
 import debounce from 'lodash/debounce';
@@ -351,9 +351,9 @@ function Search() {
         if (
           searchConfig.min_rating !== null &&
           searchConfig.max_rating !== null &&
-          (listing.average_rating === null ||
-            listing.average_rating < searchConfig.min_rating ||
-            listing.average_rating > searchConfig.max_rating)
+          (getOverallRatings(listing) === null ||
+            getOverallRatings(listing) < searchConfig.min_rating ||
+            getOverallRatings(listing) > searchConfig.max_rating)
         ) {
           return false;
         }

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -348,12 +348,13 @@ function Search() {
       )
       .filter((listing) => {
         // Apply filters.
+        const average_rating = getOverallRatings(listing);
         if (
           searchConfig.min_rating !== null &&
           searchConfig.max_rating !== null &&
-          (getOverallRatings(listing) === null ||
-            getOverallRatings(listing) < searchConfig.min_rating ||
-            getOverallRatings(listing) > searchConfig.max_rating)
+          (average_rating === null ||
+            average_rating < searchConfig.min_rating ||
+            average_rating > searchConfig.max_rating)
         ) {
           return false;
         }

--- a/frontend/src/pages/Search.module.css
+++ b/frontend/src/pages/Search.module.css
@@ -21,6 +21,7 @@
 }
 
 .search_container {
+  position: relative;
   width: 100%;
   border-radius: 0.5rem;
   box-shadow: 0 2px 6px 0px rgba(0, 0, 0, 0.2);
@@ -132,6 +133,7 @@
   padding: 7px;
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
+  z-index: 10;
 }
 
 .search_tab:hover {


### PR DESCRIPTION
-Don't preserve visibility of search form
-Fix bug where the "show search form" icon isn't clickable on displays where the form is taller than the screen height
-Use overall same professor ratings in overall rating slider
-Visually update rating sliders when resetting filters

Issue was the positioning of the form being weird when the screen is too short, causing the icon to be placed behind something.