### PR TITLE
Make eval filter multitoggle focusable

### DIFF
--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -398,6 +398,26 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
     { displayName: `Prof (${items['professor'].length})`, value: 'professor' },
   ];
 
+  // Hold index of each filter option
+  const options_indx = {
+    course: 0,
+    both: 1,
+    professor: 2,
+  };
+
+  // Switch filter if left or right arrow key is pressed
+  const handleKeyDown = (e) => {
+    if (e.keyCode === 37) {
+      // Left arrow key
+      const new_indx = (options_indx[filter] + 2) % 3;
+      setFilter(options[new_indx].value);
+    } else if (e.keyCode === 39) {
+      // Right arrow key
+      const new_indx = (options_indx[filter] + 1) % 3;
+      setFilter(options[new_indx].value);
+    }
+  };
+
   return (
     <Modal.Body>
       <Row className="m-auto">
@@ -629,7 +649,13 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
         {/* Course Evaluations */}
         <Col md={5} className="px-0 my-0">
           {/* Filter Select */}
-          <Row className="m-auto justify-content-center">
+          <Row
+            className={
+              Styles.filter_container + ' m-auto justify-content-center'
+            }
+            onKeyDown={handleKeyDown}
+            tabIndex={0}
+          >
             <StyledMultiToggle
               options={options}
               selectedOption={filter}

--- a/frontend/src/components/CourseModalOverview.module.css
+++ b/frontend/src/components/CourseModalOverview.module.css
@@ -70,6 +70,10 @@
   color: rgb(252, 105, 105);
 }
 
+.filter_container:focus {
+  outline: none;
+}
+
 @media (hover: none) {
   .rating_bubble {
     max-height: 3rem;

--- a/frontend/src/components/CourseModalOverview.module.css
+++ b/frontend/src/components/CourseModalOverview.module.css
@@ -74,6 +74,10 @@
   outline: none;
 }
 
+.filter_container:focus-visible .evaluations_filter {
+  outline: 2px solid #468ff2;
+}
+
 @media (hover: none) {
   .rating_bubble {
     max-height: 3rem;


### PR DESCRIPTION
Toggle between eval filters using arrow keys on focus. Should I add some UI indication that the user has focused on the multitoggle?