### PR TITLE
Conditional hotkeys

### DIFF
--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -565,8 +565,8 @@ function Search() {
   return (
     <div className={Styles.search_base}>
       <GlobalHotKeys
-        keyMap={keyMap}
-        handlers={handlers}
+        keyMap={course_modal[0] ? {} : keyMap}
+        handlers={course_modal[0] ? {} : handlers}
         allowChanges // required for global
         style={{ outline: 'none' }}
       />


### PR DESCRIPTION
- Global hotkeys in search bar no longer active when modal is open, allowing ctrl-f search.