### PR TITLE
Show all courses on modal (and other optimizations)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,3 +23,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/src/generated

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -140,7 +140,6 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
       const evaluations = [];
       // Loop by season code
       data.computed_listing_info.forEach((season) => {
-        if (!season.course.evaluation_statistics[0]) return;
         // Stores the average rating for all profs teaching this course and populates prof_info
         let average_professor_rating = 0;
         if (season.professor_info) {
@@ -167,15 +166,13 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
         }
         evaluations.push({
           // Course rating
-          rating:
-            season.course.evaluation_statistics[0].avg_rating != null
-              ? season.course.evaluation_statistics[0].avg_rating
-              : -1,
+          rating: season.course.evaluation_statistics[0]
+            ? season.course.evaluation_statistics[0].avg_rating || -1
+            : -1,
           // Workload rating
-          workload:
-            season.course.evaluation_statistics[0].avg_workload != null
-              ? season.course.evaluation_statistics[0].avg_workload
-              : -1,
+          workload: season.course.evaluation_statistics[0]
+            ? season.course.evaluation_statistics[0].avg_workload || -1
+            : -1,
           // Professor rating
           professor_rating: average_professor_rating || -1,
           // Season code
@@ -209,10 +206,6 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
 
       // Loop through each listing with evals
       for (let i = 0; i < evaluations.length; i++) {
-        // Skip listings that have no ratings (therefore prolly don't have comments and graphs)
-        if (evaluations[i].rating === -1 && evaluations[i].workload === -1)
-          continue;
-
         const eval_box = (
           <Row key={id++} className="m-auto py-1 justify-content-center">
             {/* Clickable listing button */}

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -206,14 +206,22 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
 
       // Loop through each listing with evals
       for (let i = 0; i < evaluations.length; i++) {
+        const hasEvals = evaluations[i].rating !== -1;
+        const evalStyle = hasEvals
+          ? Styles.rating_bubble
+          : Styles.rating_bubble_unclickable;
         const eval_box = (
           <Row key={id++} className="m-auto py-1 justify-content-center">
             {/* Clickable listing button */}
             <StyledCol
               xs={5}
-              className={`${Styles.rating_bubble}  px-0 mr-3 text-center`}
-              onClick={() => handleSetSeason(evaluations[i])}
-              style={{ flex: 'none' }}
+              className={`${evalStyle}  px-0 mr-3 text-center`}
+              onClick={hasEvals ? () => handleSetSeason(evaluations[i]) : null}
+              style={
+                hasEvals
+                  ? { flex: 'none' }
+                  : { flex: 'none', background: '#d3d3d3' }
+              }
             >
               <strong>{toSeasonString(evaluations[i].season_code)[0]}</strong>
               <div className={`${Styles.details} mx-auto ${Styles.shown}`}>

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -29,7 +29,7 @@ const StyledCol = styled(Col)`
 `;
 
 // Unclickable version of StyledCol for courses with no evaluations
-const StyledCol_unclickable = styled(Col)`
+const StyledColUnclickable = styled(Col)`
   background-color: ${({ theme }) => theme.surface};
 `;
 
@@ -232,7 +232,7 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
                 </div>
               </StyledCol>
             ) : (
-              <StyledCol_unclickable
+              <StyledColUnclickable
                 xs={5}
                 className={`${Styles.rating_bubble_unclickable}  px-0 mr-3 text-center`}
                 style={{ flex: 'none' }}
@@ -245,7 +245,7 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
                     ? `Section ${evaluations[i].section}`
                     : evaluations[i].professor[0]}
                 </div>
-              </StyledCol_unclickable>
+              </StyledColUnclickable>
             )}
             {/* Course Rating */}
             <Col

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -28,6 +28,11 @@ const StyledCol = styled(Col)`
     theme.theme === 'light' ? 'rgb(190, 221, 255)' : theme.select_hover};
 `;
 
+// Unclickable version of StyledCol for courses with no evaluations
+const StyledCol_unclickable = styled(Col)`
+  background-color: ${({ theme }) => theme.surface};
+`;
+
 // Multitoggle in modal (course, both, prof)
 export const StyledMultiToggle = styled(MultiToggle)`
   background-color: ${({ theme }) => theme.surface[1]};
@@ -207,31 +212,41 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
       // Loop through each listing with evals
       for (let i = 0; i < evaluations.length; i++) {
         const hasEvals = evaluations[i].rating !== -1;
-        const evalStyle = hasEvals
-          ? Styles.rating_bubble
-          : Styles.rating_bubble_unclickable;
         const eval_box = (
           <Row key={id++} className="m-auto py-1 justify-content-center">
-            {/* Clickable listing button */}
-            <StyledCol
-              xs={5}
-              className={`${evalStyle}  px-0 mr-3 text-center`}
-              onClick={hasEvals ? () => handleSetSeason(evaluations[i]) : null}
-              style={
-                hasEvals
-                  ? { flex: 'none' }
-                  : { flex: 'none', background: '#d3d3d3' }
-              }
-            >
-              <strong>{toSeasonString(evaluations[i].season_code)[0]}</strong>
-              <div className={`${Styles.details} mx-auto ${Styles.shown}`}>
-                {filter === 'professor'
-                  ? evaluations[i].course_code[0]
-                  : filter === 'both'
-                  ? `Section ${evaluations[i].section}`
-                  : evaluations[i].professor[0]}
-              </div>
-            </StyledCol>
+            {/* The listing button, either clickable or greyed out based on whether evaluations exist */}
+            {hasEvals ? (
+              <StyledCol
+                xs={5}
+                className={`${Styles.rating_bubble}  px-0 mr-3 text-center`}
+                onClick={() => handleSetSeason(evaluations[i])}
+                style={{ flex: 'none' }}
+              >
+                <strong>{toSeasonString(evaluations[i].season_code)[0]}</strong>
+                <div className={`${Styles.details} mx-auto ${Styles.shown}`}>
+                  {filter === 'professor'
+                    ? evaluations[i].course_code[0]
+                    : filter === 'both'
+                    ? `Section ${evaluations[i].section}`
+                    : evaluations[i].professor[0]}
+                </div>
+              </StyledCol>
+            ) : (
+              <StyledCol_unclickable
+                xs={5}
+                className={`${Styles.rating_bubble_unclickable}  px-0 mr-3 text-center`}
+                style={{ flex: 'none' }}
+              >
+                <strong>{toSeasonString(evaluations[i].season_code)[0]}</strong>
+                <div className={`${Styles.details} mx-auto ${Styles.shown}`}>
+                  {filter === 'professor'
+                    ? evaluations[i].course_code[0]
+                    : filter === 'both'
+                    ? `Section ${evaluations[i].section}`
+                    : evaluations[i].professor[0]}
+                </div>
+              </StyledCol_unclickable>
+            )}
             {/* Course Rating */}
             <Col
               xs={2}

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -235,7 +235,7 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
               <StyledColUnclickable
                 xs={5}
                 className={`${Styles.rating_bubble_unclickable}  px-0 mr-3 text-center`}
-                style={{ flex: 'none' }}
+                style={{ flex: 'none', color: '#b5b5b5' }}
               >
                 <strong>{toSeasonString(evaluations[i].season_code)[0]}</strong>
                 <div className={`${Styles.details} mx-auto ${Styles.shown}`}>

--- a/frontend/src/components/CourseModalOverview.module.css
+++ b/frontend/src/components/CourseModalOverview.module.css
@@ -11,7 +11,8 @@
   font-weight: 600;
 }
 
-.rating_bubble {
+.rating_bubble,
+.rating_bubble_unclickable {
   /* background-color: rgb(190, 221, 255); */
   border-radius: 8px;
   /* HAVE RATING BUBBLE ANIMATION */
@@ -27,6 +28,12 @@
   background-color: rgb(92, 168, 250);
   max-height: 50px;
   cursor: pointer;
+  transition: max-height 0.2s ease-in;
+}
+
+.rating_bubble_unclickable:hover {
+  max-height: 50px;
+  cursor: not-allowed;
   transition: max-height 0.2s ease-in;
 }
 

--- a/frontend/src/components/SearchResultsGridItem.js
+++ b/frontend/src/components/SearchResultsGridItem.js
@@ -72,14 +72,6 @@ const SearchResultsGridItem = ({
   // Fetch overall rating value and string representation
   const course_rating = useMemo(() => getOverallRatings(course), [course]);
 
-  // Has the component been mounted yet?
-  const [mounted, setMounted] = useState(false);
-
-  // Set mounted on mount
-  useEffect(() => {
-    if (!mounted) setMounted(true);
-  }, [mounted]);
-
   // Variable used in list keys
   let key = 0;
 
@@ -358,12 +350,10 @@ const SearchResultsGridItem = ({
           modal={false}
         />
       </div>
-      {/* Render conflict icon only when component has been mounted */}
-      {mounted && (
-        <div className={styles.conflict_error}>
-          <CourseConflictIcon course={course} />
-        </div>
-      )}
+      {/* Render conflict icon */}
+      <div className={styles.conflict_error}>
+        <CourseConflictIcon course={course} />
+      </div>
     </Col>
   );
 };

--- a/frontend/src/components/SearchResultsGridItem.js
+++ b/frontend/src/components/SearchResultsGridItem.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Row, Col, Badge, OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import chroma from 'chroma-js';

--- a/frontend/src/components/SearchResultsItem.js
+++ b/frontend/src/components/SearchResultsItem.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { Badge, OverlayTrigger, Popover, Tooltip, Row } from 'react-bootstrap';
 

--- a/frontend/src/components/SearchResultsItem.js
+++ b/frontend/src/components/SearchResultsItem.js
@@ -52,14 +52,6 @@ const SearchResultsItem = ({
   expanded,
   fb_friends,
 }) => {
-  // Has the component been mounted?
-  const [mounted, setMounted] = useState(false);
-
-  // Set mounted on mount
-  useEffect(() => {
-    if (!mounted) setMounted(true);
-  }, [mounted]);
-
   // Season code for this listing
   const { season_code } = course;
   const season = season_code[5];
@@ -338,12 +330,10 @@ const SearchResultsItem = ({
           modal={false}
         />
       </div>
-      {/* Render conflict icon only when component has been mounted */}
-      {mounted && (
-        <div className={Styles.conflict_error}>
-          <CourseConflictIcon course={course} />
-        </div>
-      )}
+      {/* Render conflict icon */}
+      <div className={Styles.conflict_error}>
+        <CourseConflictIcon course={course} />
+      </div>
     </StyledResultsItem>
   );
 };

--- a/frontend/src/components/SearchResultsItem.js
+++ b/frontend/src/components/SearchResultsItem.js
@@ -339,7 +339,7 @@ const SearchResultsItem = ({
         />
       </div>
       {/* Render conflict icon only when component has been mounted */}
-      {mounted && !isScrolling && (
+      {mounted && (
         <div className={Styles.conflict_error}>
           <CourseConflictIcon course={course} />
         </div>

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -148,6 +148,11 @@ function Search() {
     'hideCancelled',
     true
   );
+  // Does the user want to hide discussion sections?
+  const [
+    hideDiscussionSections,
+    setHideDiscussionSections,
+  ] = useSessionStorageState('hideDiscussionSections', true);
   // Does the user want to hide first year seminars?
   const [
     hideFirstYearSeminars,
@@ -300,6 +305,7 @@ function Search() {
       min_workload: include_all_workloads ? null : workloadBounds[0],
       max_workload: include_all_workloads ? null : workloadBounds[1],
       extra_info: hideCancelled ? 'ACTIVE' : null,
+      discussion_section: hideDiscussionSections ? 'ACTIVE' : null,
       fy_sem: hideFirstYearSeminars ? false : null,
       grad_level: hideGraduateCourses ? false : null,
     };
@@ -313,6 +319,7 @@ function Search() {
     return search_variables;
   }, [
     hideCancelled,
+    hideDiscussionSections,
     hideFirstYearSeminars,
     hideGraduateCourses,
     ratingBounds,
@@ -368,6 +375,13 @@ function Search() {
         if (
           searchConfig.extra_info !== null &&
           searchConfig.extra_info !== listing.extra_info
+        ) {
+          return false;
+        }
+
+        if (
+          searchConfig.discussion_section !== null &&
+          listing.title === 'Discussion Section'
         ) {
           return false;
         }
@@ -525,6 +539,7 @@ function Search() {
   // reset the search form
   const handleResetFilters = () => {
     setHideCancelled(true);
+    setHideDiscussionSections(true);
     setHideFirstYearSeminars(false);
     setHideGraduateCourses(false);
     setRatingBounds([1, 5]);
@@ -802,6 +817,21 @@ function Search() {
                     }}
                   >
                     Hide cancelled courses
+                  </Form.Check.Label>
+                </Form.Check>
+
+                {/* Hide Discussion Sections Toggle */}
+                <Form.Check type="switch" className={Styles.toggle_option}>
+                  <Form.Check.Input
+                    checked={hideDiscussionSections}
+                    onChange={(e) => {}} // dummy handler to remove warning
+                  />
+                  <Form.Check.Label
+                    onClick={() => {
+                      setHideDiscussionSections(!hideDiscussionSections);
+                    }}
+                  >
+                    Hide discussion sections
                   </Form.Check.Label>
                 </Form.Check>
 

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -381,7 +381,8 @@ function Search() {
 
         if (
           searchConfig.discussion_section !== null &&
-          listing.title === 'Discussion Section'
+          (listing.title === 'Discussion Section' ||
+            listing.title === 'Discussion section')
         ) {
           return false;
         }


### PR DESCRIPTION
**Primary Issue**
* Show all historical courses in the modal even if they don't have evaluations. Relevant issue (in more detail): https://github.com/coursetable/coursetable/issues/639

**Secondary Issues (see linked issues)** 
* Show course conflict icon when scrolling
* Add generated files from graphql to gitignore
* Add toggle to hide discussion sections in the search panel