### PR TITLE
Small updates

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -63,7 +63,9 @@ function App({ themeToggler }) {
       <Notice>
         Want to try out the latest features and shape the future of CourseTable?
         Become a Beta Tester{' '}
-        <a href="https://forms.gle/UtD5YnZ7MzxYLTux6">here</a>!
+        <a href="https://forms.gle/UtD5YnZ7MzxYLTux6">here</a>, or{' '}
+        <a href="https://www.linkedin.com/company/coursetable">follow us</a> on
+        LinkedIn for the latest updates.
       </Notice>
       <Navbar isLoggedIn={isLoggedIn} themeToggler={themeToggler} />
       <Switch>

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -211,6 +211,8 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
 
       // Loop through each listing with evals
       for (let i = 0; i < evaluations.length; i++) {
+        // Skip listings in the current season that have no evals
+        if (evaluations[i].season_code === '202103') continue;
         const hasEvals = evaluations[i].rating !== -1;
         const eval_box = (
           <Row key={id++} className="m-auto py-1 justify-content-center">

--- a/frontend/src/components/CourseModalOverview.js
+++ b/frontend/src/components/CourseModalOverview.js
@@ -211,8 +211,9 @@ const CourseModalOverview = ({ setFilter, filter, setSeason, listing }) => {
 
       // Loop through each listing with evals
       for (let i = 0; i < evaluations.length; i++) {
-        // Skip listings in the current season that have no evals
-        if (evaluations[i].season_code === '202103') continue;
+        // Skip listings in the current and future seasons that have no evals
+        if (['202102', '202103', '202201'].includes(evaluations[i].season_code))
+          continue;
         const hasEvals = evaluations[i].rating !== -1;
         const eval_box = (
           <Row key={id++} className="m-auto py-1 justify-content-center">

--- a/frontend/src/components/CourseModalOverview.module.css
+++ b/frontend/src/components/CourseModalOverview.module.css
@@ -33,7 +33,7 @@
 
 .rating_bubble_unclickable:hover {
   max-height: 50px;
-  cursor: not-allowed;
+  cursor: default;
   transition: max-height 0.2s ease-in;
 }
 

--- a/frontend/src/components/MeDropdown.tsx
+++ b/frontend/src/components/MeDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import posthog from 'posthog-js';
 import { Row, Col, Collapse } from 'react-bootstrap';
 import { FaFacebookSquare, FaSignOutAlt, FaSignInAlt } from 'react-icons/fa';
-import { FcCalendar, FcUndo } from 'react-icons/fc';
+import { FcCalendar } from 'react-icons/fc';
 import FBLoginButton from './FBLoginButton';
 
 import styles from './MeDropdown.module.css';

--- a/frontend/src/components/MeDropdown.tsx
+++ b/frontend/src/components/MeDropdown.tsx
@@ -79,22 +79,6 @@ const MeDropdown: React.VFC<Props> = ({
         {/* This wrapper div is important for making the collapse animation smooth */}
         <div>
           <Col className="px-3 pt-3">
-            {/* Revert to Old CourseTable Link */}
-            <Row className=" pb-3 m-auto">
-              <FcUndo
-                className="mr-2 my-auto"
-                size={20}
-                style={{ paddingLeft: '2px' }}
-              />
-              <TextComponent type={1}>
-                <a
-                  href="https://old.coursetable.com/"
-                  className={styles.collapse_text}
-                >
-                  <StyledHoverText>Old CourseTable</StyledHoverText>
-                </a>
-              </TextComponent>
-            </Row>
             {/* Export Worksheet button */}
             {isLoggedIn && (
               <Row className=" pb-3 m-auto">

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -194,14 +194,6 @@ function CourseTableNavbar({
                 </div>
                 {/* Sign in/out and Facebook buttons. Show if mobile */}
                 <div className="d-md-none">
-                  <StyledDiv>
-                    <a
-                      href="https://old.coursetable.com/"
-                      style={{ color: 'inherit' }}
-                    >
-                      Old CourseTable
-                    </a>
-                  </StyledDiv>
                   {!isLoggedIn ? (
                     <StyledDiv
                       onClick={() => {

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -106,9 +106,7 @@ function FAQ() {
           <NavLink to="/feedback" onClick={scrollToTop}>
             let us know
           </NavLink>
-          . You can also revert to the{' '}
-          <a href="https://old.coursetable.com/">old CourseTable site</a> if you
-          prefer it.
+          .
         </>
       ),
     },

--- a/frontend/src/pages/Search.js
+++ b/frontend/src/pages/Search.js
@@ -124,7 +124,7 @@ function Search() {
     select_seasons,
     setSelectSeasons,
   ] = useSessionStorageState('select_seasons', [
-    { value: '202101', label: 'Spring 2021' },
+    { value: '202103', label: 'Fall 2021' },
   ]);
   const [select_skillsareas, setSelectSkillsAreas] = useSessionStorageState(
     'select_skillsareas',
@@ -545,7 +545,7 @@ function Search() {
     setHideGraduateCourses(false);
     setRatingBounds([1, 5]);
     setWorkloadBounds([1, 5]);
-    setSelectSeasons([{ value: '202101', label: 'Spring 2021' }]);
+    setSelectSeasons([{ value: '202103', label: 'Fall 2021' }]);
     setSelectSkillsAreas(null);
     setSelectCredits(null);
     setSelectSchools([]);


### PR DESCRIPTION
Minor updates for when we roll out the new semester:
* Set default season to Fall 2021 in the search bar
* Remove old coursetable link from the user dropdown
* Update banner to link to the coursetable LinkedIn page
* Set hover pointer to default for courses with no evals
* Hide courses without evals from current and future seasons in the course modal

(Done. See linked issues for details.)