### PR TITLE
PostHog backend analytics

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "morgan": "^1.10.0",
     "passport": "^0.4.1",
     "passport-cas": "git+https://github.com/coursetable/passport-cas",
-    "posthog-node": "^1.0.7",
+    "posthog-node": "1.0.7",
     "prisma": "^2.19.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4",

--- a/api/package.json
+++ b/api/package.json
@@ -44,6 +44,7 @@
     "morgan": "^1.10.0",
     "passport": "^0.4.1",
     "passport-cas": "git+https://github.com/coursetable/passport-cas",
+    "posthog-node": "^1.0.7",
     "prisma": "^2.19.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4",

--- a/api/src/auth/auth.handlers.ts
+++ b/api/src/auth/auth.handlers.ts
@@ -11,7 +11,7 @@ import winston from '../logging/winston';
 
 import axios from 'axios';
 
-import { YALIES_API_KEY } from '../config';
+import { YALIES_API_KEY, POSTHOG_CLIENT } from '../config';
 
 import { PrismaClient } from '@prisma/client';
 
@@ -153,6 +153,15 @@ export const passportConfig = async (
           },
         })
         .then((student) => {
+          POSTHOG_CLIENT.identify({
+            distinctId: netId,
+            properties: {
+              email: student?.email || '',
+              firstName: student?.first_name || '',
+              lastName: student?.last_name || '',
+            },
+          });
+
           done(null, {
             netId,
             evals: !!student?.evaluationsEnabled,

--- a/api/src/auth/auth.handlers.ts
+++ b/api/src/auth/auth.handlers.ts
@@ -109,6 +109,22 @@ export const passportConfig = async (
                 curriculum: user.curriculum,
               },
             });
+
+            // Update user in PostHog
+            POSTHOG_CLIENT.identify({
+              distinctId: profile.user,
+              properties: {
+                email: user.email || '',
+                firstName: user.first_name || '',
+                lastName: user.last_name || '',
+                upi: user.upi || -1,
+                school: user.school || '',
+                college: user.college || '',
+                major: user.major || '',
+                curriculum: user.curriculum || '',
+              },
+            });
+
             return done(null, {
               netId: profile.user,
               evals: !!user.school_code,
@@ -153,15 +169,6 @@ export const passportConfig = async (
           },
         })
         .then((student) => {
-          POSTHOG_CLIENT.identify({
-            distinctId: netId,
-            properties: {
-              email: student?.email || '',
-              firstName: student?.first_name || '',
-              lastName: student?.last_name || '',
-            },
-          });
-
           done(null, {
             netId,
             evals: !!student?.evaluationsEnabled,

--- a/api/src/auth/auth.routes.ts
+++ b/api/src/auth/auth.routes.ts
@@ -5,6 +5,8 @@
 import express from 'express';
 import passport from 'passport';
 
+import { POSTHOG_CLIENT } from '../config';
+
 import { casLogin } from './auth.handlers';
 
 /**
@@ -29,6 +31,13 @@ export default async (app: express.Express): Promise<void> => {
 
   // Logouts
   app.get('/api/auth/logout', (req, res) => {
+    if (req.user) {
+      POSTHOG_CLIENT.capture({
+        distinctId: req.user?.netId,
+        event: 'update-facebook-friends',
+      });
+    }
+
     req.logOut();
     return res.json({ success: true });
   });

--- a/api/src/auth/auth.routes.ts
+++ b/api/src/auth/auth.routes.ts
@@ -33,8 +33,8 @@ export default async (app: express.Express): Promise<void> => {
   app.get('/api/auth/logout', (req, res) => {
     if (req.user) {
       POSTHOG_CLIENT.capture({
-        distinctId: req.user?.netId,
-        event: 'update-facebook-friends',
+        distinctId: req.user.netId,
+        event: 'api-logout',
       });
     }
 

--- a/api/src/canny/canny.handlers.ts
+++ b/api/src/canny/canny.handlers.ts
@@ -97,6 +97,11 @@ export const cannyIdentify = async (
         },
       });
 
+      POSTHOG_CLIENT.capture({
+        distinctId: netId,
+        event: 'request-canny-token',
+      });
+
       const token = createCannyToken({
         netId,
         evals: !!user.school_code,

--- a/api/src/canny/canny.handlers.ts
+++ b/api/src/canny/canny.handlers.ts
@@ -3,7 +3,7 @@
  */
 import express from 'express';
 
-import { YALIES_API_KEY, CANNY_KEY } from '../config';
+import { YALIES_API_KEY, CANNY_KEY, POSTHOG_CLIENT } from '../config';
 
 import { User } from '../models/student';
 
@@ -81,6 +81,22 @@ export const cannyIdentify = async (
           curriculum: user.curriculum,
         },
       });
+
+      // Update user in PostHog
+      POSTHOG_CLIENT.identify({
+        distinctId: netId,
+        properties: {
+          email: user.email || '',
+          firstName: user.first_name || '',
+          lastName: user.last_name || '',
+          upi: user.upi || -1,
+          school: user.school || '',
+          college: user.college || '',
+          major: user.major || '',
+          curriculum: user.curriculum || '',
+        },
+      });
+
       const token = createCannyToken({
         netId,
         evals: !!user.school_code,

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -1,6 +1,7 @@
 /**
  * @file Global server configurations
  */
+import PostHog from 'posthog-node';
 
 const die = (err: string) => {
   throw new Error(`env config missing: ${err}`);
@@ -60,3 +61,8 @@ export const { FERRY_SECRET } = process.env;
 // Location of statically generated files. This is relative
 // to the working directory, which is api.
 export const STATIC_FILE_DIR = './static';
+
+const POSTHOG_CLIENT = new PostHog(
+  getEnv('POSTHOG_API_KEY'),
+  { host: getEnv('POSTHOG_HOST') } // You can remove this line if you're using app.posthog.com
+);

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -62,7 +62,6 @@ export const { FERRY_SECRET } = process.env;
 // to the working directory, which is api.
 export const STATIC_FILE_DIR = './static';
 
-const POSTHOG_CLIENT = new PostHog(
-  getEnv('POSTHOG_API_KEY'),
-  { host: getEnv('POSTHOG_HOST') } // You can remove this line if you're using app.posthog.com
-);
+export const POSTHOG_CLIENT = new PostHog(getEnv('POSTHOG_API_KEY'), {
+  host: getEnv('POSTHOG_HOST'),
+});

--- a/api/src/facebook/facebook.handlers.ts
+++ b/api/src/facebook/facebook.handlers.ts
@@ -6,7 +6,7 @@ import express from 'express';
 
 import axios from 'axios';
 
-import { FACEBOOK_API_ENDPOINT } from '../config';
+import { FACEBOOK_API_ENDPOINT, POSTHOG_CLIENT } from '../config';
 
 import winston from '../logging/winston';
 
@@ -35,6 +35,11 @@ export const updateFriends = async (
   }
 
   const { netId } = req.user;
+
+  POSTHOG_CLIENT.capture({
+    distinctId: netId,
+    event: 'update-facebook-friends',
+  });
 
   // User's Facebook token for fetching their friends
   const fbToken = req.headers['fb-token'];
@@ -160,6 +165,11 @@ export const disconnectFacebook = async (
 
   const { netId } = req.user;
 
+  POSTHOG_CLIENT.capture({
+    distinctId: netId,
+    event: 'disconnect-facebook',
+  });
+
   try {
     winston.info(`Removing Facebook friends for user ${netId}`);
     await prisma.studentFacebookFriends.deleteMany({
@@ -198,6 +208,11 @@ export const getFriendsWorksheets = async (
   }
 
   const { netId } = req.user;
+
+  POSTHOG_CLIENT.capture({
+    distinctId: netId,
+    event: 'get-facebook-worksheets',
+  });
 
   // Get Facebook ID of user
   winston.info("Getting user's Facebook ID");

--- a/api/src/posthog.d.ts
+++ b/api/src/posthog.d.ts
@@ -1,0 +1,13 @@
+import 'posthog-node';
+
+// Temporary fix because the official type declarations are incorrect
+// TODO: remove this once posthog-node fixes their index.d.ts
+
+// Based on https://styled-components.com/docs/api#typescript.
+declare module 'posthog-node' {
+  interface IdentifyMessage {
+    distinctId: string;
+    event?: string;
+    properties?: CommonParamsInterfacePropertiesProp;
+  }
+}

--- a/api/src/user/user.handlers.ts
+++ b/api/src/user/user.handlers.ts
@@ -6,6 +6,8 @@ import express from 'express';
 
 import winston from '../logging/winston';
 
+import { POSTHOG_CLIENT } from '../config';
+
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
@@ -29,6 +31,16 @@ export const toggleBookmark = async (
   const { netId } = req.user;
 
   const { action, season, ociId } = req.body;
+
+  POSTHOG_CLIENT.capture({
+    distinctId: netId,
+    event: 'toggle-bookmark',
+    properties: {
+      action,
+      season,
+      ociId,
+    },
+  });
 
   // Add a bookmarked course
   if (action === 'add') {
@@ -77,6 +89,11 @@ export const getUserWorksheet = async (
   }
 
   const { netId } = req.user;
+
+  POSTHOG_CLIENT.capture({
+    distinctId: netId,
+    event: 'fetch-worksheets',
+  });
 
   // Get user info
   winston.info(`Getting profile for user ${netId}`);

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -561,6 +561,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+axios-retry@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.9.tgz#6c30fc9aeb4519aebaec758b90ef56fa03fe72e8"
+  integrity sha512-NFCoNIHq8lYkJa6ku4m+V1837TP6lCa7n79Iuf8/AqATAHYB0ISaAS1eyIenDOfHOLtym34W65Sjke2xjg2fsA==
+  dependencies:
+    is-retry-allowed "^1.1.0"
+
 axios@*, axios@^0.21.0, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -679,6 +686,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -753,6 +765,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+component-type@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-type/-/component-type-1.2.1.tgz#8a47901700238e4fc32269771230226f24b415a9"
+  integrity sha1-ikeQFwAjjk/DIml3EjAibyS0Fak=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -854,6 +871,11 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1686,6 +1708,11 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.0"
 
+is-buffer@~1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
 is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
@@ -1753,6 +1780,11 @@ is-regex@^1.1.2:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
+is-retry-allowed@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
+  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
+
 is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
@@ -1784,6 +1816,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+join-component@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/join-component/-/join-component-1.1.0.tgz#b8417b750661a392bee2c2537c68b2a9d4977cd5"
+  integrity sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU=
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1998,6 +2035,15 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
 
+md5@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -2102,7 +2148,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2376,6 +2422,20 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+posthog-node@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/posthog-node/-/posthog-node-1.0.7.tgz#a7a9525eebff23312117e57cff3ddac82afb2262"
+  integrity sha512-KTCwyU+PU1eAQtjy5ZSJ47mrxv2d/mMkxo+vvV5c+YqfE4mBAY1UPEPMv1nElb5Vq0UnxvyQXaUnOn8d8Xr6Eg==
+  dependencies:
+    axios "^0.21.1"
+    axios-retry "^3.1.9"
+    component-type "^1.2.1"
+    join-component "^1.1.0"
+    md5 "^2.3.0"
+    ms "^2.1.3"
+    remove-trailing-slash "^0.1.1"
+    uuid "^8.3.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -2523,6 +2583,11 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
+remove-trailing-slash@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz#be2285a59f39c74d1bce4f825950061915e3780d"
+  integrity sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==
 
 repeating@^2.0.0:
   version "2.0.1"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2422,7 +2422,7 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-posthog-node@^1.0.7:
+posthog-node@1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/posthog-node/-/posthog-node-1.0.7.tgz#a7a9525eebff23312117e57cff3ddac82afb2262"
   integrity sha512-KTCwyU+PU1eAQtjy5ZSJ47mrxv2d/mMkxo+vvV5c+YqfE4mBAY1UPEPMv1nElb5Vq0UnxvyQXaUnOn8d8Xr6Eg==

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1159,9 +1159,9 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.23.0:
-  version "7.23.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.23.0.tgz#8d029d252f6e8cf45894b4bee08f5493f8e94325"
-  integrity sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
+  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.0"
@@ -1494,9 +1494,9 @@ globals@^12.1.0:
     type-fest "^0.8.1"
 
 globals@^13.6.0:
-  version "13.7.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.7.0.tgz#aed3bcefd80ad3ec0f0be2cf0c895110c0591795"
-  integrity sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
+  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
   dependencies:
     type-fest "^0.20.2"
 
@@ -2081,12 +2081,12 @@ methods@~1.1.2:
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
 micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.3.tgz#fdad8352bf0cbeb89b391b5d244bc22ff3dd4ec8"
+  integrity sha512-ueuSaP4i67F/FAUac9zzZ0Dz/5KeKDkITYIS/k4fps+9qeh1SkeH6gbljcqz97mNBOsaWZ+iv2UobMKK/yD+aw==
   dependencies:
     braces "^3.0.1"
-    picomatch "^2.0.5"
+    picomatch "^2.2.1"
 
 mime-db@1.47.0:
   version "1.47.0"
@@ -2393,7 +2393,7 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -3051,9 +3051,9 @@ unbox-primitive@^1.0.0:
     which-boxed-primitive "^1.0.2"
 
 underscore@^1.12.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.0.tgz#3ccdcbb824230fc6bf234ad0ddcd83dff4eafe5f"
+  integrity sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       MYSQL_PASSWORD: ${MYSQL_ROOT_PASSWORD?password}
       MYSQL_URL: ${MYSQL_URL?mysql_url}
       NODE_ENV: development
+      POSTHOG_API_KEY: ${POSTHOG_API_KEY?posthog_api_key}
+      POSTHOG_HOST: ${POSTHOG_HOST?posthog_host}
       SESSION_SECRET: ${SESSION_SECRET?session_secret}
       STUDENTS_DB: yaleplus
       YALIES_API_KEY: ${YALIES_API_KEY?yalies_api_key}

--- a/docker/prod-compose.yml
+++ b/docker/prod-compose.yml
@@ -27,6 +27,8 @@ services:
       MYSQL_PASSWORD: ${MYSQL_ROOT_PASSWORD?password}
       MYSQL_URL: ${MYSQL_URL?mysql_url}
       NODE_ENV: production
+      POSTHOG_API_KEY: ${POSTHOG_API_KEY?posthog_api_key}
+      POSTHOG_HOST: ${POSTHOG_HOST?posthog_host}
       SESSION_SECRET: ${SESSION_SECRET?session_secret}
       STUDENTS_DB: yaleplus
       YALIES_API_KEY: ${YALIES_API_KEY?yalies_api_key}


### PR DESCRIPTION
Adds PostHog analytics to backend events. Because we are integrated with Yalies.io, this means we also track and store info such as year, residential college, graduation, etc., allowing us to get much more detailed user analytics than before (we only have NetIDs from frontend analytics).

Also mitigates the issue of PostHog being blocked by certain adblockers.