### PR TITLE
beta/feedback-navlink

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -288,14 +288,6 @@ function CourseTableNavbar({
                       <StyledNavLink to="/worksheet" onClick={scrollToTop}>
                         Worksheet
                       </StyledNavLink>
-                      {/* Catalog Page */}
-                      <StyledNavLink
-                        to="/feedback"
-                        onClick={scrollToTop}
-                        id="feedback-link"
-                      >
-                        Feedback
-                      </StyledNavLink>
                     </>
                   )}
                   {(isMobile || !isLoggedIn) && (


### PR DESCRIPTION
remove feedback navlink from navbar. the main motivation behind this is to save horizontal space especially at lower screen resolutions. also, since the new banner already links to the feedback page, it feels redundant.