### PR TITLE
Update Calendar export from Spring 2021 to Spring 2022

### DIFF
--- a/frontend/src/components/GenerateICS.tsx
+++ b/frontend/src/components/GenerateICS.tsx
@@ -13,13 +13,9 @@ import FileSaver from 'file-saver';
 
 // Is this day during a break?
 const onBreak = (day: moment.Moment) => {
-  // Spring 2021 Breaks
+  // Spring 2022 Breaks
   const breaks = [
-    [moment('2021-02-22T00:01'), moment('2021-02-22T23:59')],
-    [moment('2021-03-09T00:01'), moment('2021-03-09T23:59')],
-    [moment('2021-03-24T00:01'), moment('2021-03-24T23:59')],
-    [moment('2021-04-08T00:01'), moment('2021-04-08T23:59')],
-    [moment('2021-04-23T00:01'), moment('2021-04-23T23:59')],
+    [moment('2022-03-19T00:01'), moment('2022-03-27T23:59')]
   ];
 
   for (let i = 0; i < breaks.length; i++) {
@@ -31,10 +27,10 @@ const onBreak = (day: moment.Moment) => {
 // generate ICS file and download it
 export const generateICS = (listings_all: Listing[]) => {
   // Season to export
-  const cur_season = '202101';
+  const cur_season = '202201';
 
-  // Spring 2021 period
-  const period = [moment('2021-02-01T08:20'), moment('2021-05-07T17:30')];
+  // Spring 2022 period
+  const period = [moment('2022-01-25T08:20'), moment('2022-04-29T17:30')];
 
   // Only get courses for the current season that have valid times
   const listings: Listing[] = [];

--- a/frontend/src/components/GenerateICS.tsx
+++ b/frontend/src/components/GenerateICS.tsx
@@ -14,9 +14,7 @@ import FileSaver from 'file-saver';
 // Is this day during a break?
 const onBreak = (day: moment.Moment) => {
   // Spring 2022 Breaks
-  const breaks = [
-    [moment('2022-03-19T00:01'), moment('2022-03-27T23:59')]
-  ];
+  const breaks = [[moment('2022-03-19T00:01'), moment('2022-03-27T23:59')]];
 
   for (let i = 0; i < breaks.length; i++) {
     if (day >= breaks[i][0] && day <= breaks[i][1]) return true;

--- a/frontend/src/components/Navbar/MeDropdown.tsx
+++ b/frontend/src/components/Navbar/MeDropdown.tsx
@@ -27,7 +27,7 @@ import { useWindowDimensions } from '../Providers/WindowDimensionsProvider';
 import { API_ENDPOINT } from '../../config';
 
 // Season to export classes from
-const CUR_SEASON = '202101';
+const CUR_SEASON = '202201';
 
 type Props = {
   profile_expanded: boolean;


### PR DESCRIPTION
Coursetable keeps exporting Spring 2021 Courses. This PR updates the course export function (which uses hardcoded season + date boundaries + breaks) and the calling function from the dropdown to the Spring 2022. 

I'm making this PR because it was easier emotionally easier to clone + grep + change than to make my own schedule calendar events because I hate that with a burning passion.