### PR TITLE
Add theme transition duration to components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && yarn prisma version && yarn openssl version
+      - run: cd api && yarn openssl version && yarn prisma version
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: npx prisma db pull && npx prisma generate
+      - run: cd api && npx prisma db pull && npx prisma generate
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && yarn openssl version && yarn prisma version
+      - run: cd api && openssl version && yarn prisma version
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && openssl version && yarn prisma --version
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && npm prestart
+      - run: cd api && yarn run prestart
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && openssl version && yarn prisma version
+      - run: cd api && openssl version && yarn prisma --version
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
+      - run: npx prisma db pull && npx prisma generate
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && yarn run prestart
+      - run: cd api && yarn prisma version && yarn openssl version
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: cd api && yarn install --frozen-lockfile
-      - run: cd api && npx prisma db pull && npx prisma generate
+      - run: cd api && npm prestart
       - run: cd api && yarn run checks
       - run: cd api && yarn run lint
 

--- a/api/package.json
+++ b/api/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.4.1",
+    "prisma": "3.10.0",
     "ts-node-dev": "^1.1.8"
   }
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/api/src/auth/auth.handlers.ts
+++ b/api/src/auth/auth.handlers.ts
@@ -12,6 +12,7 @@ import winston from '../logging/winston';
 import axios from 'axios';
 
 import { YALIES_API_KEY, POSTHOG_CLIENT, prisma } from '../config';
+import { StudentBluebookSettings } from '@prisma/client';
 
 // codes for allowed organizations (to give faculty access to the site)
 const ALLOWED_ORG_CODES = [
@@ -195,7 +196,7 @@ export const passportConfig = async (
           netId,
         },
       })
-      .then((student) => {
+      .then((student: StudentBluebookSettings | null) => {
         done(null, {
           netId,
           evals: !!student?.evaluationsEnabled,

--- a/api/src/user/user.handlers.ts
+++ b/api/src/user/user.handlers.ts
@@ -7,6 +7,7 @@ import express from 'express';
 import winston from '../logging/winston';
 
 import { POSTHOG_CLIENT, prisma } from '../config';
+import { WorksheetCourses } from '@prisma/client';
 
 /**
  * Toggle a bookmarked course in a worksheet.
@@ -113,7 +114,7 @@ export const getUserWorksheet = async (
     evaluationsEnabled: studentProfile?.evaluationsEnabled,
     year: studentProfile?.year,
     school: studentProfile?.school,
-    data: worksheets.map((course) => [
+    data: worksheets.map((course: WorksheetCourses) => [
       String(course.season),
       String(course.oci_id),
     ]),

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,11 +24,7 @@ import GraphiqlLogin from './pages/GraphiqlLogin';
 import { useUser } from './contexts/userContext';
 import { useLocalStorageState } from './browserStorage';
 import { useWindowDimensions } from './components/Providers/WindowDimensionsProvider';
-import { API_ENDPOINT } from './config';
-
-import { WiStars } from 'react-icons/wi';
-import { BsBookmarkFill } from 'react-icons/bs';
-import { FaVoteYea } from 'react-icons/fa';
+import { lightTheme } from './components/Themes';
 
 /**
  * Render navbar and the corresponding page component for the route the user is on
@@ -88,6 +84,10 @@ function App({ themeToggler, location }) {
     location,
     setIsTutorialOpen,
   ]);
+
+  useEffect(() => {
+    document.body.style.transition = `background-color ${lightTheme.trans_dur}`;
+  }, []);
 
   // Render spinner if page loading
   if (loading) {

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import { NavLink } from 'react-router-dom';
 import { Container } from 'react-bootstrap';
 import styles from './Footer.module.css';
 import Logo from './Navbar/Logo';
+import styled from 'styled-components';
 import { StyledHr, TextComponent } from './StyledComponents';
 
 import { scrollToTop } from '../utilities';
@@ -10,6 +11,11 @@ import { scrollToTop } from '../utilities';
 import VercelBanner from '../images/powered-by-vercel.svg';
 
 import { API_ENDPOINT } from '../config';
+
+// Header
+const StyledH5 = styled.h5`
+  transition: color ${({ theme }) => theme.trans_dur};
+`;
 
 /**
  * Footer
@@ -39,7 +45,7 @@ const Footer: React.VFC = () => {
             </a>
           </div>
           <div className="col-6 col-md">
-            <h5>Explore</h5>
+            <StyledH5>Explore</StyledH5>
             <ul className="list-unstyled text-small">
               {/* Catalog */}
               <li>
@@ -56,7 +62,7 @@ const Footer: React.VFC = () => {
             </ul>
           </div>
           <div className="col-6 col-md">
-            <h5>Support</h5>
+            <StyledH5>Support</StyledH5>
             <ul className="list-unstyled text-small">
               {/* FAQ */}
               <li>
@@ -88,7 +94,7 @@ const Footer: React.VFC = () => {
             </ul>
           </div>
           <div className="col-6 col-md">
-            <h5>Developers</h5>
+            <StyledH5>Developers</StyledH5>
             <ul className="list-unstyled text-small">
               {/* GraphQL explorer */}
               <li>
@@ -99,7 +105,7 @@ const Footer: React.VFC = () => {
             </ul>
           </div>
           <div className="col-6 col-md">
-            <h5>About</h5>
+            <StyledH5>About</StyledH5>
             <ul className="list-unstyled text-small">
               {/* Team */}
               <li>

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -34,6 +34,9 @@ const StyledMeIcon = styled.div`
   height: 30px;
   border-radius: 15px;
   display: flex;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
   &:hover {
     cursor: pointer;
     color: ${({ theme }) => theme.primary};
@@ -61,6 +64,7 @@ const StyledNavLink = styled(NavLink)`
   font-weight: 500;
   font-size: 1rem;
   ${breakpoints('font-size', 'rem', [{ 1320: 0.9 }])};
+  transition: color ${({ theme }) => theme.trans_dur};
   &:hover {
     text-decoration: none !important;
     color: ${({ theme }) => theme.primary};

--- a/frontend/src/components/Navbar/NavbarCatalogSearch.tsx
+++ b/frontend/src/components/Navbar/NavbarCatalogSearch.tsx
@@ -82,6 +82,7 @@ const RangeLabel = styled.div`
   ${breakpoints('font-size', 'px', [{ 1320: 12 }])};
   user-select: none;
   cursor: default;
+  transition: color ${({ theme }) => theme.trans_dur};
 `;
 
 // Range filter value label
@@ -90,6 +91,7 @@ const RangeValueLabel = styled.div`
   ${breakpoints('font-size', 'px', [{ 1320: 10 }])};
   user-select: none;
   cursor: default;
+  transition: color ${({ theme }) => theme.trans_dur};
 `;
 
 // Wrapper for advanced filters dropdown
@@ -165,6 +167,7 @@ const CloseIcon = styled(IoClose)`
   margin-left: -30px;
   cursor: pointer;
   color: ${({ theme }) => theme.icon_focus};
+  transition: color ${({ theme }) => theme.trans_dur};
   &:hover {
     color: ${({ theme }) =>
       theme.theme === 'light'

--- a/frontend/src/components/Navbar/NavbarWorksheetSearch.tsx
+++ b/frontend/src/components/Navbar/NavbarWorksheetSearch.tsx
@@ -41,7 +41,9 @@ const StyledToggleButton = styled(ToggleButton)`
   background-color: ${({ theme }) => theme.surface[0]};
   color: ${({ theme }) => theme.text[0]};
   border: ${({ theme }) => theme.icon} 2px solid;
-  transition: 0s;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
   padding: 0.25rem 0;
   width: 50%;
 

--- a/frontend/src/components/Search/ListGridToggle.tsx
+++ b/frontend/src/components/Search/ListGridToggle.tsx
@@ -6,6 +6,7 @@ const StyledToggle = styled.div`
   color: ${({ theme }) => theme.text[1]};
   padding: 7.5px;
   border-radius: 15px;
+  transition: color ${({ theme }) => theme.trans_dur};
   &:hover {
     cursor: pointer;
     background-color: ${({ theme }) => theme.select};

--- a/frontend/src/components/Search/Popout.tsx
+++ b/frontend/src/components/Search/Popout.tsx
@@ -39,6 +39,9 @@ const StyledButton = styled.div`
   border-radius: 4px;
   user-select: none;
   cursor: pointer;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 
   &:hover {
     background-color: ${({ theme }) => theme.button_hover};
@@ -56,12 +59,25 @@ const ClearIcon = styled(IoClose)`
   z-index: 1000;
   cursor: pointer;
   color: ${({ theme }) => theme.icon_focus};
+  transition: color ${({ theme }) => theme.trans_dur};
   &:hover {
     color: ${({ theme }) =>
       theme.theme === 'light'
         ? chroma(theme.icon_focus).darken().css()
         : chroma(theme.icon_focus).brighten().css()};
   }
+`;
+
+// Down icon
+const DownIcon = styled(IoMdArrowDropdown)`
+  color: ${({ theme }) => theme.icon_focus};
+  transition: color ${({ theme }) => theme.trans_dur};
+`;
+
+// Up icon
+const UpIcon = styled(IoMdArrowDropup)`
+  color: ${({ theme }) => theme.icon_focus};
+  transition: color ${({ theme }) => theme.trans_dur};
 `;
 
 type Option = {
@@ -266,15 +282,9 @@ export const Popout: React.FC<Props> = ({
           <ClearIcon className="ml-1" onClick={onClear} />
         ) : arrowIcon ? (
           isComponentVisible ? (
-            <IoMdArrowDropup
-              className="ml-1"
-              style={{ color: theme.icon_focus }}
-            />
+            <DownIcon className="ml-1" />
           ) : (
-            <IoMdArrowDropdown
-              className="ml-1"
-              style={{ color: theme.icon_focus }}
-            />
+            <UpIcon className="ml-1" />
           )
         ) : (
           <></>

--- a/frontend/src/components/Search/Results.jsx
+++ b/frontend/src/components/Search/Results.jsx
@@ -39,6 +39,7 @@ import { Link } from 'react-router-dom';
 // Space above row dropdown to hide scrolled courses
 const StyledSpacer = styled.div`
   background-color: ${({ theme }) => theme.background};
+  transition: background-color ${({ theme }) => theme.trans_dur};
   position: -webkit-sticky; /* Safari */
   position: sticky;
   z-index: 2;
@@ -48,6 +49,9 @@ const StyledSpacer = styled.div`
 const StyledContainer = styled(SurfaceComponent)`
   border-top: 2px solid ${({ theme }) => theme.border};
   border-bottom: 2px solid ${({ theme }) => theme.border};
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 `;
 
 // Restrict the row width
@@ -70,6 +74,12 @@ const SearchResults = styled.div`
   overflow: hidden;
   ${({ numCourses, isMobile }) =>
     numCourses > 0 && numCourses < 20 && !isMobile ? 'height: 80vh;' : ''}
+`;
+
+// Results item wrapper
+const ResultsItemWrapper = styled.div`
+  transition: background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 `;
 
 // Function to calculate column width within a max and min
@@ -213,7 +223,7 @@ const Results = ({
           ? { backgroundColor: globalTheme.surface[0] }
           : { backgroundColor: globalTheme.row_odd };
       return (
-        <div
+        <ResultsItemWrapper
           style={{
             ...style,
             ...colorStyles,
@@ -229,7 +239,7 @@ const Results = ({
             isScrolling={isScrolling}
             fb_friends={fb_friends}
           />
-        </div>
+        </ResultsItemWrapper>
       );
     },
     [data, showModal, multiSeasons, COL_SPACING, num_fb, globalTheme]

--- a/frontend/src/components/Search/ResultsColumnSort.tsx
+++ b/frontend/src/components/Search/ResultsColumnSort.tsx
@@ -18,6 +18,7 @@ const StyledSortBtn = styled.div`
   cursor: pointer;
   border-radius: 4px;
   padding: 2px;
+  transition: background-color ${({ theme }) => theme.trans_dur};
   &:hover {
     background-color: ${({ theme }) => theme.button_active};
   }

--- a/frontend/src/components/Search/ResultsGridItem.jsx
+++ b/frontend/src/components/Search/ResultsGridItem.jsx
@@ -35,6 +35,9 @@ const StyledGridItem = styled.div`
       : theme.theme === 'light'
       ? 'rgb(245, 245, 245)'
       : theme.surface[1]};
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
   &:hover {
     background-color: ${({ theme }) => theme.select_hover};
   }

--- a/frontend/src/components/Search/ResultsGridItem.module.css
+++ b/frontend/src/components/Search/ResultsGridItem.module.css
@@ -3,7 +3,6 @@
 }
 
 .container:hover {
-  transform: scale(1.03);
   cursor: pointer;
 }
 

--- a/frontend/src/components/StyledComponents.tsx
+++ b/frontend/src/components/StyledComponents.tsx
@@ -6,11 +6,13 @@ import { breakpoints } from '../utilities';
 // Div used to color the background of surface components
 export const SurfaceComponent = styled.div<{ layer: number }>`
   background-color: ${({ theme, layer }) => theme.surface[layer]};
+  transition: background-color ${({ theme }) => theme.trans_dur};
 `;
 
 // Span used to color text. Type is an int that represents primary (0) or secondary (1) color
 export const TextComponent = styled.span<{ type: number }>`
   color: ${({ theme, type }) => theme.text[type]};
+  transition: color ${({ theme }) => theme.trans_dur};
 `;
 
 // Small text component
@@ -46,6 +48,9 @@ export const StyledInput = styled(FormControl)`
   border: solid 2px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   padding: 0.375rem 0.75rem;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 
   &:hover {
     border: 2px solid hsl(0, 0%, 70%);
@@ -64,11 +69,14 @@ export const StyledInput = styled(FormControl)`
 export const StyledHr = styled.hr`
   border-color: ${({ theme }) =>
     theme.theme === 'light' ? '#ededed' : '#404040'};
+  transition: border-color ${({ theme }) => theme.trans_dur};
 `;
 
 // Card used in Worksheet mobile and about page
 export const StyledCard = styled(Card)`
   background-color: ${({ theme }) => theme.surface[0]};
+  transition: background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 `;
 
 // Expand buttons in worksheet and worksheet expanded
@@ -78,12 +86,18 @@ export const StyledExpandBtn = styled.div`
   position: absolute;
   top: 0%;
   z-index: 2;
-  transition: transform 0.05s linear;
+  transition: transform 0.05s linear,
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 `;
 
 // Popovers in search results item, prof popover in modal, and worksheet calendar
 export const StyledPopover = styled(Popover)`
   background-color: ${({ theme }) => theme.surface[0]};
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
+
   .popover-header {
     background-color: ${({ theme }) => theme.banner};
     color: ${({ theme }) => theme.text[1]};
@@ -118,6 +132,7 @@ export const StyledRating = styled.div<{
 // Primary Color link
 export const StyledLink = styled.span`
   color: ${({ theme }) => theme.primary};
+  transition: color ${({ theme }) => theme.trans_dur};
   &:hover {
     color: ${({ theme }) => theme.primary_hover};
     cursor: pointer;

--- a/frontend/src/components/Themes.ts
+++ b/frontend/src/components/Themes.ts
@@ -26,6 +26,7 @@ export const lightTheme: DefaultTheme = {
   primary_light: 'rgba(70, 143, 242, 0.15)', // Primary color (lighter blue)
   primary_hover: '#007bff', // Primary hover color (dark blue)
   row_odd: '#f9f9f9', // Odd row background color
+  trans_dur: '0.35s', // Transition duration
 };
 export const darkTheme: DefaultTheme = {
   theme: 'dark',
@@ -48,4 +49,5 @@ export const darkTheme: DefaultTheme = {
   primary_light: 'rgba(68, 100, 145, 0.25)', // Primary color (lighter blue)
   primary_hover: '#007bff', // Primary hover color (blue)
   row_odd: '#202020', // Odd row background color
+  trans_dur: '0.35s', // Transition duration
 };

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -5,7 +5,7 @@ import { Calendar, momentLocalizer } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import styled from 'styled-components';
 import CalendarEvent from './CalendarEvent';
-import { theme_transition_duration, weekdays } from '../../utilities/common';
+import { weekdays } from '../../utilities/common';
 import { useWorksheet } from '../../contexts/worksheetContext';
 import { Listing } from '../Providers/FerryProvider';
 

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -5,7 +5,7 @@ import { Calendar, momentLocalizer } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import styled from 'styled-components';
 import CalendarEvent from './CalendarEvent';
-import { weekdays } from '../../utilities/common';
+import { theme_transition_duration, weekdays } from '../../utilities/common';
 import { useWorksheet } from '../../contexts/worksheetContext';
 import { Listing } from '../Providers/FerryProvider';
 
@@ -28,29 +28,35 @@ const StyledCalendar = styled(Calendar)`
       .rbc-time-header {
         .rbc-time-header-content {
           border-color: ${({ theme }) => theme.border};
+          transition: border-color ${({ theme }) => theme.trans_dur};
           .rbc-time-header-cell {
             .rbc-header {
               user-select: none;
               cursor: default;
               border-color: ${({ theme }) => theme.border};
+              transition: border-color ${({ theme }) => theme.trans_dur};
             }
           }
         }
       }
       .rbc-time-content {
         border-color: ${({ theme }) => theme.border};
+        transition: border-color ${({ theme }) => theme.trans_dur};
         .rbc-time-gutter {
           .rbc-timeslot-group {
             user-select: none;
             cursor: default;
             border-color: ${({ theme }) => theme.border};
+            transition: border-color ${({ theme }) => theme.trans_dur};
           }
         }
         .rbc-day-slot {
           .rbc-timeslot-group {
             border-color: ${({ theme }) => theme.border};
+            transition: border-color ${({ theme }) => theme.trans_dur};
             .rbc-time-slot {
               border-color: ${({ theme }) => theme.border};
+              transition: border-color ${({ theme }) => theme.trans_dur};
           }
         }
       }

--- a/frontend/src/components/Worksheet/WorksheetCalendarList.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendarList.tsx
@@ -14,6 +14,9 @@ const StyledSpacer = styled.div`
   position: sticky;
   top: 56px;
   z-index: 2;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 `;
 
 // Hide icon
@@ -39,6 +42,9 @@ const StyledBtn = styled.div`
   justify-content: center;
   align-items: center;
   user-select: none;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
 
   &:hover {
     border: 2px solid hsl(0, 0%, 70%);
@@ -84,18 +90,18 @@ function WorksheetCalendarList() {
   // Build the HTML for the list of courses of a given season
   const items = useMemo(() => {
     // List to hold HTML
-    const items = courses.map((course, id) => {
+    const listitems = courses.map((course, id) => {
       let hidden = false;
       if (Object.prototype.hasOwnProperty.call(hidden_courses, cur_season)) {
         hidden = hidden_courses[cur_season][course.crn];
       }
-      // Add listgroup item to items list
+      // Add listgroup item to listitems list
       return (
         <WorksheetCalendarListItem key={id} course={course} hidden={hidden} />
       );
     });
 
-    return items;
+    return listitems;
   }, [courses, hidden_courses, cur_season]);
 
   const areHidden = useMemo(() => {

--- a/frontend/src/components/Worksheet/WorksheetCalendarListItem.module.css
+++ b/frontend/src/components/Worksheet/WorksheetCalendarListItem.module.css
@@ -1,7 +1,3 @@
-.list_text {
-  overflow: hidden;
-}
-
 .course_title {
   display: block;
   width: 100%;

--- a/frontend/src/components/Worksheet/WorksheetCalendarListItem.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendarListItem.tsx
@@ -12,6 +12,9 @@ const StyledListItem = styled(ListGroup.Item)`
   background-color: transparent;
   border-color: ${({ theme }) => theme.border};
   overflow: hidden;
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
   &:hover {
     cursor: pointer;
     background-color: ${({ theme }) => theme.select_hover};
@@ -24,6 +27,12 @@ const StyledListItem = styled(ListGroup.Item)`
   &:hover .hidden {
     opacity: 1;
   }
+`;
+
+// Course code
+const StyledCol = styled(Col)`
+  overflow: hidden;
+  transition: color ${({ theme }) => theme.trans_dur};
 `;
 
 /**
@@ -55,15 +64,15 @@ function WorksheetCalendarListItem({
     >
       <Row className="align-items-center mx-auto">
         {/* Course Code and Title */}
-        <Col
-          className={`${styles.list_text} pl-1 pr-2`}
+        <StyledCol
+          className={'pl-1 pr-2'}
           style={color_style}
           onClick={() => showModal(course)}
         >
           <strong>{course.course_code}</strong>
           <br />
           <span className={styles.course_title}>{course.title}</span>
-        </Col>
+        </StyledCol>
         {/* Hide Button */}
         <div className={`mr-1 my-auto ${hidden ? 'visible' : 'hidden'}`}>
           <WorksheetHideButton

--- a/frontend/src/pages/About.module.css
+++ b/frontend/src/pages/About.module.css
@@ -3,12 +3,6 @@
   margin-bottom: 3rem;
 }
 
-.about_header {
-  font-weight: 600;
-  font-size: 25px;
-  text-align: center;
-}
-
 .about_description {
   font-weight: 500;
   font-size: 15px;

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { Card, Button, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import styles from './About.module.css';
@@ -42,6 +42,14 @@ import hl from '../images/headshots/hao-li.jpg';
 import df from '../images/headshots/dylan-fernandez-de-lara.jpg';
 
 // import generic from '../images/headshots/default_pfp.png';
+
+// Header
+const StyledH1 = styled.h1`
+  font-weight: 600;
+  font-size: 25px;
+  text-align: center;
+  transition: color ${({ theme }) => theme.trans_dur};
+`;
 
 /**
  * Renders the about us page
@@ -251,7 +259,7 @@ const About: React.VFC = () => {
 
   return (
     <div className={`${styles.container} mx-auto`}>
-      <h1 className={`${styles.about_header} mt-5 mb-1`}>About Us</h1>
+      <StyledH1 className={'mt-5 mb-1'}>About Us</StyledH1>
       <TextComponent type={1}>
         <p className={`${styles.about_description} mb-3 mx-auto`}>
           CourseTable offers a clean and effective way for Yale students to find

--- a/frontend/src/pages/FAQ.module.css
+++ b/frontend/src/pages/FAQ.module.css
@@ -1,8 +1,3 @@
-.container {
-  width: 600px;
-  margin-bottom: 3rem;
-}
-
 .faq_header {
   font-weight: 600;
   font-size: 25px;

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -14,11 +14,20 @@ const StyledCard = styled(Card)`
   background-color: transparent;
   border: none !important;
   border-bottom: 1px solid ${({ theme }) => theme.border} !important;
+  transition: border-color ${({ theme }) => theme.trans_dur};
 
   .active {
     border-bottom: 1px solid ${({ theme }) => theme.border} !important;
     color: ${({ theme }) => theme.primary};
+    transition: border-color ${({ theme }) => theme.trans_dur};
   }
+`;
+
+// Container for FAQ
+const StyledContainer = styled.div`
+  width: 600px;
+  margin-bottom: 3rem;
+  transition: color ${({ theme }) => theme.trans_dur};
 `;
 
 // Custom accordion component
@@ -278,7 +287,7 @@ const FAQ: React.VFC = () => {
   ];
 
   return (
-    <div className={`${styles.container} mx-auto`}>
+    <StyledContainer className={'mx-auto'}>
       <h1 className={`${styles.faq_header} mt-5 mb-1`}>
         Frequently Asked Questions
       </h1>
@@ -300,7 +309,7 @@ const FAQ: React.VFC = () => {
           </StyledCard>
         ))}
       </Accordion>
-    </div>
+    </StyledContainer>
   );
 };
 

--- a/frontend/src/pages/Worksheet.jsx
+++ b/frontend/src/pages/Worksheet.jsx
@@ -21,6 +21,14 @@ import { useWindowDimensions } from '../components/Providers/WindowDimensionsPro
 import { useWorksheet } from '../contexts/worksheetContext';
 import * as Sentry from '@sentry/react';
 
+import styled from 'styled-components';
+
+const StyledCalendarContainer = styled(SurfaceComponent)`
+  transition: border-color ${({ theme }) => theme.trans_dur},
+    background-color ${({ theme }) => theme.trans_dur},
+    color ${({ theme }) => theme.trans_dur};
+`;
+
 /**
  * Renders worksheet page
  */
@@ -121,7 +129,7 @@ function Worksheet() {
                   : 'pr-3 '
               }${worksheet_view.view === 'list' ? styles.hidden : ''}`}
             >
-              <SurfaceComponent
+              <StyledCalendarContainer
                 layer={0}
                 className={styles.calendar_style_container}
               >
@@ -155,7 +163,7 @@ function Worksheet() {
                     />
                   )}
                 </StyledExpandBtn>
-              </SurfaceComponent>
+              </StyledCalendarContainer>
             </Col>
             {/* List Component */}
             <Col

--- a/frontend/src/styled.d.ts
+++ b/frontend/src/styled.d.ts
@@ -23,5 +23,6 @@ declare module 'styled-components' {
     primary_light: string;
     primary_hover: string;
     row_odd: string;
+    trans_dur: string;
   }
 }


### PR DESCRIPTION
Instead of instantaneously switching between light and dark mode, there is now a duration to decrease how jarring it is. This duration is in a centralized location (`lightTheme.trans_dur`/`darkTheme.trans_dur` in `frontend/src/components/Themes.ts`).