### PR TITLE
Expand CORS to http localhost and .yaleapps.com

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -48,9 +48,11 @@ export const FRONTEND_ENDPOINT = isDev
 export const CORS_OPTIONS = {
   origin: [
     'https://localhost:3000',
+    'http://localhost:3000',
     'https://coursetable.com',
     'https://www.coursetable.com',
     /\.coursetable\.com$/,
+    /\.yaleapps\.com$/,
     /\.vercel\.app$/,
   ],
   credentials: true,


### PR DESCRIPTION
Add support for http://localhost and .yaleapps.com domains in CORS configuration