### PR TITLE
fix OCE links

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -30,7 +30,7 @@ Once these requirements are met, a challenge is produced as follows:
 
    Random selection is implemented by choosing a random float between 1 and 5 and selecting questions with a mean response just above this threshold (accomplished by sorting the responses in order of ascending mean rating and limiting to the first three).
 
-2. For each question, we randomly choose one of the five response options for the user to go fetch the number of respondents. For ease of access, we auto-generate the OCE URL from the template `https://oce.app.yale.edu/oce-viewer/studentSummary/index?crn=<CRN>&term_code=<SEASON>`.
+2. For each question, we randomly choose one of the five response options for the user to go fetch the number of respondents. For ease of access, we auto-generate the OCE URL from the template `https://oce.app.yale.edu/ocedashboard/studentViewer/courseSummary?crn=<CRN>&termCode=<SEASON>`.
 
 3. An object containing the question-response bucket combinations, the user's NetID, and a salt value is JSON-stringified and encrypted into a token using a secret unknown to the user. This affords us the following points of security:
 

--- a/api/src/challenge/challenge.controllers.ts
+++ b/api/src/challenge/challenge.controllers.ts
@@ -88,7 +88,7 @@ const constructChallenge = (
     const { crn } = x.course.listings[0];
     const season = x.course.season_code;
 
-    return `https://oce.app.yale.edu/oce-viewer/studentSummary/index?crn=${crn}&term_code=${season}`;
+    return `https://oce.app.yale.edu/ocedashboard/studentViewer/courseSummary?crn=${crn}&termCode=${season}`;
   });
 
   // merged course information object

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -138,7 +138,7 @@ const FAQ: React.VFC = () => {
           </a>
           ,{' '}
           <a
-            href="https://oce.app.yale.edu/oce-viewer/studentViewer/index"
+            href="https://oce.app.yale.edu/ocedashboard/studentViewer"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/src/pages/Privacy.tsx
+++ b/frontend/src/pages/Privacy.tsx
@@ -310,7 +310,7 @@ const Privacy: React.VFC = () => {
           </a>
           ,{' '}
           <a
-            href="https://oce.app.yale.edu/oce-viewer/studentViewer/index"
+            href="https://oce.app.yale.edu/ocedashboard/studentViewer"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Many in the '27 Discord server have realized that first-years signing onto CourseTable for the first time are unable to complete verification due to the OCE link being updated from the old `https://oce.app.yale.edu/oce-viewer/studentSummary/index?term_code=<CODE>` to `https://oce.app.yale.edu/ocedashboard/studentViewer/courseSummary?crn=<CRN>&termCode=<CODE>`. This PR updates the links throughout this repo.

I also have found that the "Overall Assessment" evaluation question seems to correspond to the question ID `YC404` in many, if not all, cases. Therefore, figuring out a way to leverage that query param could lead users directly to the question page, removing the extra step of reading through the questions list and clicking on the correct one to see the chart. However, the link for that would be `https://oce.app.yale.edu/ocedashboard/studentViewer/numeric?crn=<CRN>&termCode=<CODE>&questionId=YC404&netIdFor=<something>&graphs=Y`, which appears to need the instructor's Net ID that I don't believe is currently exposed through the CourseTable API in the challenge query, so this would require additional implementation.