### PR TITLE
Removed a disturbing margin wrapping the notice component

### DIFF
--- a/frontend/src/components/Notice.tsx
+++ b/frontend/src/components/Notice.tsx
@@ -19,7 +19,7 @@ const Notice: React.FC = ({ children }) => {
   }
 
   return (
-    <StyledBanner className={styles.banner} style={{ margin: '1.5px' }}>
+    <StyledBanner className={styles.banner}>
       <div className={styles.content}>
         <div>{children}</div>
       </div>


### PR DESCRIPTION
Before:
<img width="495" alt="Before" src="https://github.com/coursetable/coursetable/assets/61620817/a26ada85-53dd-41be-9d15-401ac7621b08">

After:
<img width="495" alt="After" src="https://github.com/coursetable/coursetable/assets/61620817/4fdec6f9-38fc-40ff-b478-6fc0f22c6dac">
