### PR TITLE
Change banner wording: work for -> work on

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -105,13 +105,13 @@ function App({ themeToggler, location }) {
   return (
     <>
       <Notice>
-        Want to work for CourseTable or join the Yale Computer Society? 
+        Want to work on CourseTable or join the Yale Computer Society?
         <a
           href="https://forms.gle/eX2Lwh39R7pPd2rb6"
           style={{ color: 'white', fontWeight: '750' }}
           target="_blank"
         >
-          &nbsp; <br></br> Apply Here! 
+          &nbsp; <br></br> Apply Here!
         </a>
       </Notice>
       <Navbar


### PR DESCRIPTION
Not to nitpick the header for a second time in a row, but this wording implied to me that working on CourseTable is a job, which may turn some people away.