### PR TITLE
Fix "Hide discussion sections" button

### DIFF
--- a/frontend/src/contexts/searchContext.tsx
+++ b/frontend/src/contexts/searchContext.tsx
@@ -623,9 +623,10 @@ export const SearchProvider: React.FC = ({ children }) => {
         return false;
       }
 
+      // Checks whether the section field consists only of letters -- if so, the class is a discussion section.
       if (
         searchConfig.discussion_section !== null &&
-        listing.title === 'Discussion Section'
+        /^[A-Z]*$/.test(listing.section)
       ) {
         return false;
       }


### PR DESCRIPTION
The "hide discussion sections" button currently checks whether the class name is "Discussion Section." This change checks whether the Section field is all letters, which is only true of discussion sections. 