### PR TITLE
fix: display past syllabi in reverse chronological order properly

### DIFF
--- a/frontend/src/components/CourseModal/CourseModalOverview.jsx
+++ b/frontend/src/components/CourseModal/CourseModalOverview.jsx
@@ -142,11 +142,11 @@ function CourseModalOverview({ setFilter, filter, setSeason, listing }) {
           (v, i, a) =>
             a.findIndex((t) => t.syllabus_url === v.syllabus_url) === i,
         )
-        .sort((a, b) => {
-          if (a.season_code > b.season_code) return -1;
-          if (b.season_code < a.season_code) return 1;
-          return parseInt(a.section, 10) > parseInt(b.section, 10) ? 1 : -1;
-        });
+        .sort(
+          (a, b) =>
+            b.season_code.localeCompare(a.season_code, 'en-US') ||
+            parseInt(a.section, 10) - parseInt(b.section, 10),
+        );
     }
     return [];
   }, [data, listing.same_course_id]);
@@ -536,6 +536,7 @@ function CourseModalOverview({ setFilter, filter, setSeason, listing }) {
                 >
                   {past_syllabi.map((course) => (
                     <a
+                      key={`${course.season_code}-${course.section}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       href={course.syllabus_url}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

The template can be skipped for small and straightforward changes, such as typo fixes.
-->

## Pre-flight checklist

- [x] I have searched for potential duplicate pull requests.
- [x] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

Fixes https://feedback.coursetable.com/bugs/p/sort-past-syllabi-chronologically

## Test plan (required)

Before:

<img width="782" alt="image" src="https://github.com/coursetable/coursetable/assets/55398995/b58fa2be-36d8-4b68-973f-a833c68a56ef">

After:

<img width="782" alt="image" src="https://github.com/coursetable/coursetable/assets/55398995/8a54848e-cf05-4379-8335-09af2bf55317">

It's mostly because of the missing `key` prop, but the sort function is wrong too, so I fixed both.