### PR TITLE
fix: do not "fix" class time before 8

### DIFF
--- a/frontend/src/components/GenerateICS.tsx
+++ b/frontend/src/components/GenerateICS.tsx
@@ -71,8 +71,8 @@ export const generateICS = (listings_all: Listing[]) => {
           .date(day.date())
           .year(day.year());
         // Correct hour
-        if (start.hour() < 8) start.add(12, 'h');
-        if (end.hour() < 8) end.add(12, 'h');
+        if (start.hour() < 7) start.add(12, 'h');
+        if (end.hour() < 7) end.add(12, 'h');
         // Calculate duration
         const duration = end.diff(start, 'minutes');
         // Add listing to events list

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -86,9 +86,10 @@ function WorksheetCalendar() {
               // Get start and end times for the listing
               const start = moment(startTime, 'HH:mm').day(1 + indx);
               const end = moment(endTime, 'HH:mm').day(1 + indx);
-              // Fix any incorrect values
-              if (start.get('hour') < 8) start.add(12, 'h');
-              if (end.get('hour') < 8) end.add(12, 'h');
+              // Try to fix any incorrect values
+              // We don't have classes before 7, but we do have classes before 8
+              if (start.get('hour') < 7) start.add(12, 'h');
+              if (end.get('hour') < 7) end.add(12, 'h');
               const value = course.course_code;
               // Add event dictionary to the list
               parsedCourses.push({

--- a/frontend/src/components/Worksheet/WorksheetMobileCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetMobileCalendar.tsx
@@ -93,8 +93,8 @@ function WorksheetMobileCalendar() {
               const start = moment(startTime, 'HH:mm').day(1 + indx);
               const end = moment(endTime, 'HH:mm').day(1 + indx);
               // Fix any incorrect values
-              if (start.get('hour') < 8) start.add(12, 'h');
-              if (end.get('hour') < 8) end.add(12, 'h');
+              if (start.get('hour') < 7) start.add(12, 'h');
+              if (end.get('hour') < 7) end.add(12, 'h');
               const value = course.course_code;
               // Add event dictionary to the list
               parsedCourses.push({

--- a/frontend/src/utilities/courseUtilities.tsx
+++ b/frontend/src/utilities/courseUtilities.tsx
@@ -67,10 +67,10 @@ export const checkConflict = (
           const cur_start = moment(courseStartTime, 'HH:mm');
           const cur_end = moment(courseEndTime, 'HH:mm');
           // Fix invalid times
-          if (listing_start.hour() < 8) listing_start.add(12, 'h');
-          if (listing_end.hour() < 8) listing_end.add(12, 'h');
-          if (cur_start.hour() < 8) cur_start.add(12, 'h');
-          if (cur_end.hour() < 8) cur_end.add(12, 'h');
+          if (listing_start.hour() < 7) listing_start.add(12, 'h');
+          if (listing_end.hour() < 7) listing_end.add(12, 'h');
+          if (cur_start.hour() < 7) cur_start.add(12, 'h');
+          if (cur_end.hour() < 7) cur_end.add(12, 'h');
           // Conflict exists
           if (
             !(listing_start > cur_end || cur_start > listing_end) &&


### PR DESCRIPTION
We have classes that happen before 8am. These classes are wrongly "fixed" to happen in the afternoon. Fixes https://coursetable.canny.io/admin/feedback/bugs/p/early-classes-show-up-in-the-evening-on-the-calendar