### PR TITLE
fix: only register each time slot once in gcal

### DIFF
--- a/frontend/src/components/Worksheet/GoogleCalendarSync/utils.ts
+++ b/frontend/src/components/Worksheet/GoogleCalendarSync/utils.ts
@@ -28,13 +28,14 @@ const getTimes = (times_by_day: Listing['times_by_day']) => {
     location: string;
   }[] = [];
 
-  for (let idx = 0; idx < 5; idx++) {
-    if (!times_by_day[weekdays[idx]]) continue;
-    for (const [startTime, endTime, location] of times_by_day[weekdays[idx]]!) {
+  for (let idx = 1; idx <= 5; idx++) {
+    const info = times_by_day[weekdays[idx - 1]];
+    if (!info) continue;
+    registerTime: for (const [startTime, endTime, location] of info) {
       for (const time of times) {
         if (time.startTime === startTime && time.endTime === endTime) {
           time.days.push(idx + 1);
-          break;
+          continue registerTime;
         }
       }
       times.push({ days: [idx + 1], startTime, endTime, location });


### PR DESCRIPTION
Prevent the same time slot from being registered twice (once as a new time)