### PR TITLE
refactor: make theme a global context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,9 +32,8 @@ const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
 /**
  * Render navbar and the corresponding page component for the route the user is on
- * @prop themeToggler - function | to toggle light/dark mode. Passed on to navbar and darkmodebutton
  */
-function App({ themeToggler }: { themeToggler: () => void }) {
+function App() {
   const location = useLocation();
   // Fetch current device
   const { isMobile, isTablet } = useWindowDimensions();
@@ -106,11 +105,7 @@ function App({ themeToggler }: { themeToggler: () => void }) {
       {/* notice bar*/}
       {/*<Notice >
     </Notice>*/}
-      <Navbar
-        isLoggedIn={isLoggedIn}
-        themeToggler={themeToggler}
-        setIsTutorialOpen={setIsTutorialOpen}
-      />
+      <Navbar isLoggedIn={isLoggedIn} setIsTutorialOpen={setIsTutorialOpen} />
       <SentryRoutes>
         {/* Home Page */}
         <Route

--- a/frontend/src/Globals.tsx
+++ b/frontend/src/Globals.tsx
@@ -2,7 +2,7 @@ import 'react-app-polyfill/stable';
 import 'core-js/features/promise/all-settled';
 import 'core-js/es/promise/all-settled';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   BrowserRouter,
   useLocation,
@@ -10,7 +10,7 @@ import {
   createRoutesFromChildren,
   matchRoutes,
 } from 'react-router-dom';
-import { ThemeProvider, createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 import { ToastContainer } from 'react-toastify';
 import {
   InMemoryCache,
@@ -29,12 +29,12 @@ import { FerryProvider } from './contexts/ferryContext';
 import { UserProvider } from './contexts/userContext';
 import { SearchProvider } from './contexts/searchContext';
 import { WorksheetProvider } from './contexts/worksheetContext';
+import { ThemeProvider } from './contexts/themeContext';
 
 import { isDev, API_ENDPOINT } from './config';
 
 import './index.css';
 
-import { lightTheme, darkTheme } from './components/Themes';
 import ErrorPage from './components/ErrorPage';
 import { Row } from 'react-bootstrap';
 
@@ -110,26 +110,7 @@ const GlobalStyles = createGlobalStyle`
   }
   `;
 
-type Theme = 'light' | 'dark';
-
 function Globals({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('light');
-
-  const setMode = (mode: Theme) => {
-    window.localStorage.setItem('theme', mode);
-    setTheme(mode);
-  };
-
-  const themeToggler = () => {
-    if (theme === 'light') setMode('dark');
-    else setMode('light');
-  };
-
-  useEffect(() => {
-    const localTheme = window.localStorage.getItem('theme') as Theme;
-    if (localTheme) setTheme(localTheme);
-  }, []);
-  const themeMode = theme === 'light' ? lightTheme : darkTheme;
   return (
     <CustomErrorBoundary>
       {/* TODO: re-enable StrictMode later */}
@@ -141,28 +122,14 @@ function Globals({ children }: { children: React.ReactNode }) {
             <WindowDimensionsProvider>
               <SearchProvider>
                 <WorksheetProvider>
-                  <BrowserRouter>
-                    <ThemeProvider theme={themeMode}>
+                  <ThemeProvider>
+                    <BrowserRouter>
                       <GlobalStyles />
                       <div id="base" style={{ height: 'auto' }}>
-                        {/* Clone child and give it the themeToggler prop */}
-                        {children &&
-                          React.Children.map(
-                            children as React.ReactElement<{
-                              themeToggler: string | (() => void);
-                            }>,
-                            (child) => {
-                              if (React.isValidElement(child)) {
-                                return React.cloneElement(child, {
-                                  themeToggler,
-                                });
-                              }
-                              return child;
-                            },
-                          )}
+                        {children}
                       </div>
-                    </ThemeProvider>
-                  </BrowserRouter>
+                    </BrowserRouter>
+                  </ThemeProvider>
                 </WorksheetProvider>
               </SearchProvider>
               {/* TODO: style toasts with bootstrap using https://fkhadra.github.io/react-toastify/how-to-style/ */}

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -21,6 +21,7 @@ import { NavbarCatalogSearch } from './NavbarCatalogSearch';
 import { DateTime, Duration } from 'luxon';
 
 import { API_ENDPOINT } from '../../config';
+import { useTheme } from '../../contexts/themeContext';
 import { NavbarWorksheetSearch } from './NavbarWorksheetSearch';
 
 // Profile icon
@@ -94,7 +95,6 @@ const NavLogo = styled(Nav)`
 
 type Props = {
   isLoggedIn: boolean;
-  themeToggler: () => void;
   setIsTutorialOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
@@ -119,14 +119,9 @@ function NavCollapseWrapper({
 /**
  * Renders the navbar
  * @prop isLoggedIn - is user logged in?
- * @prop themeToggler - which toggles between light and dark mode
  * @prop setIsTutorialOpen - opens tutorial
  */
-function CourseTableNavbar({
-  isLoggedIn,
-  themeToggler,
-  setIsTutorialOpen,
-}: Props) {
+function CourseTableNavbar({ isLoggedIn, setIsTutorialOpen }: Props) {
   const location = useLocation();
   // Is navbar expanded in mobile view?
   const [nav_expanded, setExpand] = useState<boolean>(false);
@@ -139,6 +134,8 @@ function CourseTableNavbar({
 
   // Last updated state
   const [lastUpdated, setLastUpdated] = useState('0 hrs');
+
+  const { toggleTheme } = useTheme();
 
   // Fetch current device
   const { isMobile, isLgDesktop } = useWindowDimensions();
@@ -261,7 +258,7 @@ function CourseTableNavbar({
                     className={`${styles.navbar_dark_mode_btn} d-flex ${
                       !isMobile ? 'ml-auto' : ''
                     }`}
-                    onClick={themeToggler}
+                    onClick={toggleTheme}
                   >
                     <DarkModeButton />
                   </div>

--- a/frontend/src/contexts/themeContext.tsx
+++ b/frontend/src/contexts/themeContext.tsx
@@ -1,0 +1,57 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { ThemeProvider as SCThemeProvider } from 'styled-components';
+import { lightTheme, darkTheme } from '../components/Themes';
+
+type Theme = 'light' | 'dark';
+
+type Store = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<Store | undefined>(undefined);
+ThemeContext.displayName = 'ThemeContext';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  const setMode = useCallback((mode: Theme) => {
+    window.localStorage.setItem('theme', mode);
+    setTheme(mode);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    if (theme === 'light') setMode('dark');
+    else setMode('light');
+  }, [theme, setMode]);
+
+  useEffect(() => {
+    const localTheme = window.localStorage.getItem('theme') as Theme;
+    if (localTheme) setTheme(localTheme);
+  }, []);
+
+  const scTheme = theme === 'light' ? lightTheme : darkTheme;
+
+  const store: Store = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+    }),
+    [theme, toggleTheme],
+  );
+
+  return (
+    <ThemeContext.Provider value={store}>
+      <SCThemeProvider theme={scTheme}>{children}</SCThemeProvider>
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext)!;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,7 +9,6 @@ const root = createRoot(domNode);
 
 root.render(
   <Globals>
-    {/* @ts-expect-error TODO: themeToggler should not be a prop; it should be a context */}
     <App />
   </Globals>,
 );


### PR DESCRIPTION
This enables a few things:

1. You can use `{ theme } = useTheme()` anywhere and get the color theme, which could enable, for example, loading different images
2. We don't use hacks to pass down the `toggleTheme` prop