### PR TITLE
fix: make total workload color map more reasonable

### DIFF
--- a/frontend/src/components/Worksheet/WorksheetStats.tsx
+++ b/frontend/src/components/Worksheet/WorksheetStats.tsx
@@ -26,7 +26,7 @@ const creditColormap = chroma
   .domain([4, 5.5]);
 const workloadColormap = chroma
   .scale(['#63b37b', '#ffeb84', '#f8696b'])
-  .domain([12, 24]);
+  .domain([12, 20]);
 
 export default function WorksheetStats() {
   const [shown, setShown] = useState(true);


### PR DESCRIPTION
The previous boundaries were totally made up, and after some trials I realized a realistic worksheet probably cannot get over 20 total workload, so this change makes the colors more indicative.