### PR TITLE
feat: lazy-load route components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,10 @@ import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Row, Spinner } from 'react-bootstrap';
 import * as Sentry from '@sentry/react';
 
+// Popular pages are eagerly fetched
+import Search from './pages/Search';
+import Worksheet from './pages/Worksheet';
+
 import Notice from './components/Notice';
 import Navbar from './components/Navbar/Navbar';
 import Footer from './components/Footer';
@@ -18,9 +22,7 @@ import { useWindowDimensions } from './contexts/windowDimensionsContext';
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
 const Landing = suspended(() => import('./pages/Landing'));
-const Search = suspended(() => import('./pages/Search'));
 const About = suspended(() => import('./pages/About'));
-const Worksheet = suspended(() => import('./pages/Worksheet'));
 const FAQ = suspended(() => import('./pages/FAQ'));
 const Privacy = suspended(() => import('./pages/Privacy'));
 const NotFound = suspended(() => import('./pages/NotFound'));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,28 +12,10 @@ import CourseModal from './components/CourseModal/CourseModal';
 
 import { useUser } from './contexts/userContext';
 import { useLocalStorageState } from './utilities/browserStorage';
+import { suspended } from './utilities/display';
 import { useWindowDimensions } from './contexts/windowDimensionsContext';
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
-
-function suspended(
-  factory: () => Promise<{ default: React.ComponentType<unknown> }>,
-) {
-  const Comp = React.lazy(factory);
-  return () => (
-    <React.Suspense
-      fallback={
-        <Row className="m-auto" style={{ width: '100%', height: '100%' }}>
-          <Spinner className="m-auto" animation="border" role="status">
-            <span className="sr-only">Loading...</span>
-          </Spinner>
-        </Row>
-      }
-    >
-      <Comp />
-    </React.Suspense>
-  );
-}
 
 const Landing = suspended(() => import('./pages/Landing'));
 const Search = suspended(() => import('./pages/Search'));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,26 +10,44 @@ import Footer from './components/Footer';
 import Tutorial from './components/Tutorial';
 import CourseModal from './components/CourseModal/CourseModal';
 
-import Landing from './pages/Landing';
-
-import Search from './pages/Search';
-import About from './pages/About';
-import Worksheet from './pages/Worksheet';
-import FAQ from './pages/FAQ';
-import Privacy from './pages/Privacy';
-import NotFound from './pages/NotFound';
-import Thankyou from './pages/Thankyou';
-import Challenge from './pages/Challenge';
-import WorksheetLogin from './pages/WorksheetLogin';
-import Graphiql from './pages/Graphiql';
-import GraphiqlLogin from './pages/GraphiqlLogin';
-import Join from './pages/Join';
-
 import { useUser } from './contexts/userContext';
 import { useLocalStorageState } from './utilities/browserStorage';
 import { useWindowDimensions } from './contexts/windowDimensionsContext';
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
+
+function suspended(
+  factory: () => Promise<{ default: React.ComponentType<unknown> }>,
+) {
+  const Comp = React.lazy(factory);
+  return () => (
+    <React.Suspense
+      fallback={
+        <Row className="m-auto" style={{ width: '100%', height: '100%' }}>
+          <Spinner className="m-auto" animation="border" role="status">
+            <span className="sr-only">Loading...</span>
+          </Spinner>
+        </Row>
+      }
+    >
+      <Comp />
+    </React.Suspense>
+  );
+}
+
+const Landing = suspended(() => import('./pages/Landing'));
+const Search = suspended(() => import('./pages/Search'));
+const About = suspended(() => import('./pages/About'));
+const Worksheet = suspended(() => import('./pages/Worksheet'));
+const FAQ = suspended(() => import('./pages/FAQ'));
+const Privacy = suspended(() => import('./pages/Privacy'));
+const NotFound = suspended(() => import('./pages/NotFound'));
+const Thankyou = suspended(() => import('./pages/Thankyou'));
+const Challenge = suspended(() => import('./pages/Challenge'));
+const WorksheetLogin = suspended(() => import('./pages/WorksheetLogin'));
+const Graphiql = suspended(() => import('./pages/Graphiql'));
+const GraphiqlLogin = suspended(() => import('./pages/GraphiqlLogin'));
+const Join = suspended(() => import('./pages/Join'));
 
 function App() {
   const location = useLocation();

--- a/frontend/src/components/CourseModal/CourseModal.tsx
+++ b/frontend/src/components/CourseModal/CourseModal.tsx
@@ -6,17 +6,17 @@ import { IoMdArrowRoundBack } from 'react-icons/io';
 import { FaRegShareFromSquare } from 'react-icons/fa6';
 import styled from 'styled-components';
 
-import CourseModalOverview, {
-  type Filter,
-  type CourseOffering,
-  type ComputedListingInfo,
+import type {
+  Filter,
+  CourseOffering,
+  ComputedListingInfo,
 } from './CourseModalOverview';
-import CourseModalEvaluations from './CourseModalEvaluations';
 import WorksheetToggleButton from '../Worksheet/WorksheetToggleButton';
 import { useWindowDimensions } from '../../contexts/windowDimensionsContext';
 import styles from './CourseModal.module.css';
 import { TextComponent, StyledLink } from '../StyledComponents';
 import SkillBadge from '../SkillBadge';
+import { suspended } from '../../utilities/display';
 import { toSeasonString } from '../../utilities/course';
 import { useCourseData } from '../../contexts/ferryContext';
 import type { Season, Crn, Listing } from '../../utilities/common';
@@ -85,6 +85,14 @@ function ShareButton({
     />
   );
 }
+
+// We can only split subviews of CourseModal because CourseModal contains core
+// logic that determines whether itself is visible.
+// Maybe we should split more code into the subviews?
+const CourseModalOverview = suspended(() => import('./CourseModalOverview'));
+const CourseModalEvaluations = suspended(
+  () => import('./CourseModalEvaluations'),
+);
 
 function CourseModal() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/frontend/src/utilities/display.tsx
+++ b/frontend/src/utilities/display.tsx
@@ -1,5 +1,6 @@
 import React, {
   type MouseEventHandler,
+  type ComponentProps,
   useEffect,
   useRef,
   useState,

--- a/frontend/src/utilities/display.tsx
+++ b/frontend/src/utilities/display.tsx
@@ -1,9 +1,35 @@
-import { type MouseEventHandler, useEffect, useRef, useState } from 'react';
+import React, {
+  type MouseEventHandler,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Row, Spinner } from 'react-bootstrap';
 import { toast } from 'react-toastify';
 import * as Sentry from '@sentry/react';
 import { css } from 'styled-components';
 
 import { API_ENDPOINT } from '../config';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function suspended<T extends React.ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+) {
+  const Comp = React.lazy(factory);
+  return (props: ComponentProps<T>) => (
+    <React.Suspense
+      fallback={
+        <Row className="m-auto" style={{ width: '100%', height: '100%' }}>
+          <Spinner className="m-auto" animation="border" role="status">
+            <span className="sr-only">Loading...</span>
+          </Spinner>
+        </Row>
+      }
+    >
+      <Comp {...props} />
+    </React.Suspense>
+  );
+}
 
 // Detect clicks outside of a component
 // Via https://stackoverflow.com/a/54570068/5004662

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         entryFileNames: 'assets/[name]-[hash:10].js',
       },
     },
+    cssCodeSplit: false,
   },
   server: {
     port: Number(process.env.PORT) || 3000,


### PR DESCRIPTION
Part of an effort to reduce bundle size. This PR makes all page components lazy-loaded, which means unless you are on the respective page, the respective code won't be loaded at all. This speeds up first page load speed, and completely avoids loading heavy dependencies like `graphiql` for 99% of our users.

Before:

<img width="1440" alt="image" src="https://github.com/coursetable/coursetable/assets/55398995/5ace8172-8678-4916-b96a-ea8e84154b35">

After:

<img width="1440" alt="image" src="https://github.com/coursetable/coursetable/assets/55398995/0c8ba596-f40a-429a-a2a2-0370fb48b50b">

The total size is the same, but note how the main bundle is significantly smaller, and chunks can be loaded on-demand only.