### PR TITLE
fix: proper prod entry and env var port routing

### DIFF
--- a/api/dev-compose.yml
+++ b/api/dev-compose.yml
@@ -1,8 +1,8 @@
 services:
   api:
     ports:
-      - '4096:4096'
-      - '3001:3001'
+      - '${INSECURE_PORT:-4096}:${INSECURE_PORT:-4096}'
+      - '${SECURE_PORT:-3001}:${SECURE_PORT:-3001}'
     volumes:
       - ../api/static:/usr/src/app/static
       - ../api/src:/usr/src/app/src

--- a/api/entry.sh
+++ b/api/entry.sh
@@ -6,5 +6,5 @@ if [ "$HOT_RELOAD" = "true" ]; then
   npm run start
 else
   # Run the server in production mode
-  npm run start
+  npm run start:prod
 fi

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
     "generate": "prisma generate",
     "prestart": "prisma generate",
     "start": "ts-node-dev --transpile-only --debug --files --exit-child src/server.ts",
-    "start:prod": "ts-node --transpile-only --files src/server.ts"
+    "start:prod": "prisma generate && ts-node --transpile-only --files src/server.ts"
   },
   "nodemonConfig": {
     "ignore": [

--- a/api/prod-compose.yml
+++ b/api/prod-compose.yml
@@ -5,8 +5,8 @@ services:
         - HOT_RELOAD=false
     restart: always
     ports:
-      - '8039:8039'
-      - '8038:8080'
+      - '${INSECURE_PORT:-8039}:${INSECURE_PORT:-8039}'
+      - '${SECURE_PORT:-8038}:${SECURE_PORT:-8038}'
     expose:
       - '8039'
     volumes:


### PR DESCRIPTION
Fixes the issue where prod had to be deployed with `npm start` in entry.sh instead of `npm start:prod`

Also changed port routing to use doppler env vars instead of hardcoding. This is also accompanied with a doppler port var change, which will need careful monitoring when deployed on prod.

New port routes tested with prod->local emulation doppler config.