### PR TITLE
refactor(api): use camelCase for all DB fields

### DIFF
--- a/api/mysql/database.sql
+++ b/api/mysql/database.sql
@@ -32,8 +32,8 @@ USE `yaleplus`;
 CREATE TABLE `StudentBluebookSettings` (
   `netId` char(8) NOT NULL,
   `evaluationsEnabled` tinyint(1) UNSIGNED NOT NULL,
-  `first_name` varchar(256) DEFAULT NULL COMMENT 'User''s first name',
-  `last_name` varchar(256) DEFAULT NULL COMMENT 'User''s last name',
+  `firstName` varchar(256) DEFAULT NULL COMMENT 'User''s first name',
+  `lastName` varchar(256) DEFAULT NULL COMMENT 'User''s last name',
   `email` varchar(256) DEFAULT NULL COMMENT 'User''s email address',
   `upi` int(11) DEFAULT NULL COMMENT 'Universal Personal Identifier used by Yale Directory',
   `school` varchar(256) DEFAULT NULL COMMENT 'User''s school',
@@ -76,10 +76,10 @@ CREATE TABLE `StudentFriendRequests` (
 
 CREATE TABLE `WorksheetCourses` (
   `id` mediumint(8) UNSIGNED NOT NULL,
-  `net_id` char(8) NOT NULL,
-  `oci_id` mediumint(8) UNSIGNED NOT NULL,
+  `netId` char(8) NOT NULL,
+  `ociId` mediumint(8) UNSIGNED NOT NULL,
   `season` mediumint(8) UNSIGNED NOT NULL,
-  `worksheet_number` mediumint(8) UNSIGNED DEFAULT 0
+  `worksheetNumber` mediumint(8) UNSIGNED DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 --
@@ -109,19 +109,12 @@ ALTER TABLE `StudentFriends`
   ADD KEY `netId` (`netId`);
 
 --
--- Indexes for table `Students`
---
-ALTER TABLE `Students`
-  ADD PRIMARY KEY (`netId`),
-  ADD KEY `facebookId` (`facebookId`);
-
---
 -- Indexes for table `WorksheetCourses`
 --
 ALTER TABLE `WorksheetCourses`
   ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `net_id_oci_id_season_worksheet_number` (`net_id`,`oci_id`,`season`, `worksheet_number`),
-  ADD KEY `net_id` (`net_id`);
+  ADD UNIQUE KEY `netId_ociId_season_worksheetNumber` (`netId`,`ociId`,`season`, `worksheetNumber`),
+  ADD KEY `netId` (`netId`);
 
 --
 -- AUTO_INCREMENT for dumped tables

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -10,8 +10,8 @@ datasource db {
 model StudentBluebookSettings {
   netId              String  @id @db.Char(8)
   evaluationsEnabled Boolean
-  first_name         String? @db.VarChar(256)
-  last_name          String? @db.VarChar(256)
+  firstName          String? @db.VarChar(256)
+  lastName           String? @db.VarChar(256)
   email              String? @db.VarChar(256)
   upi                Int?
   school             String? @db.VarChar(256)
@@ -23,8 +23,8 @@ model StudentBluebookSettings {
 }
 
 model StudentFriends {
-  id         BigInt @id @default(autoincrement()) @db.UnsignedBigInt
-  netId      String @db.Char(8)
+  id          BigInt @id @default(autoincrement()) @db.UnsignedBigInt
+  netId       String @db.Char(8)
   friendNetId String @db.Char(8)
 
   @@unique([netId, friendNetId], name: "netId_friendNetId", map: "netId_friendNetId")
@@ -32,8 +32,8 @@ model StudentFriends {
 }
 
 model StudentFriendRequests {
-  id         BigInt @id @default(autoincrement()) @db.UnsignedBigInt
-  netId      String @db.Char(8)
+  id          BigInt @id @default(autoincrement()) @db.UnsignedBigInt
+  netId       String @db.Char(8)
   friendNetId String @db.Char(8)
 
   @@unique([netId, friendNetId], name: "netId_friendNetId", map: "netId_friendNetId")
@@ -41,12 +41,12 @@ model StudentFriendRequests {
 }
 
 model WorksheetCourses {
-  id               Int    @id @default(autoincrement()) @db.UnsignedMediumInt
-  net_id           String @db.Char(8)
-  oci_id           Int    @db.UnsignedMediumInt
-  season           Int    @db.UnsignedMediumInt
-  worksheet_number Int?   @default(0) @db.UnsignedMediumInt
+  id              Int    @id @default(autoincrement()) @db.UnsignedMediumInt
+  netId           String @db.Char(8)
+  ociId           Int    @db.UnsignedMediumInt
+  season          Int    @db.UnsignedMediumInt
+  worksheetNumber Int?   @default(0) @db.UnsignedMediumInt
 
-  @@unique([net_id, oci_id, season, worksheet_number], map: "net_id_oci_id_season_worksheet_number")
-  @@index([net_id], map: "net_id")
+  @@unique([netId, ociId, season, worksheetNumber], map: "netId_ociId_season_worksheetNumber")
+  @@index([netId], map: "netId")
 }

--- a/api/src/auth/auth.handlers.ts
+++ b/api/src/auth/auth.handlers.ts
@@ -132,8 +132,8 @@ export const passportConfig = (
             },
             data: {
               evaluationsEnabled: enableEvals,
-              first_name: user.first_name,
-              last_name: user.last_name,
+              firstName: user.first_name,
+              lastName: user.last_name,
               email: user.email,
               upi: user.upi,
               school: user.school,
@@ -189,8 +189,8 @@ export const passportConfig = (
       evals: Boolean(student?.evaluationsEnabled),
       // Convert nulls to undefined
       email: student?.email ?? undefined,
-      firstName: student?.first_name ?? undefined,
-      lastName: student?.last_name ?? undefined,
+      firstName: student?.firstName ?? undefined,
+      lastName: student?.lastName ?? undefined,
     });
   });
 };

--- a/api/src/canny/canny.handlers.ts
+++ b/api/src/canny/canny.handlers.ts
@@ -70,8 +70,8 @@ export const cannyIdentify = async (
       data: {
         // Enable evaluations if user has a school code
         evaluationsEnabled: Boolean(user.school_code),
-        first_name: user.first_name,
-        last_name: user.last_name,
+        firstName: user.first_name,
+        lastName: user.last_name,
         email: user.email,
         upi: user.upi,
         school: user.school,

--- a/api/src/friends/friends.handlers.ts
+++ b/api/src/friends/friends.handlers.ts
@@ -190,8 +190,8 @@ export const getRequestsForFriend = async (
 
   const friendNames = friendInfos.map((friendInfo) => ({
     netId: friendInfo.netId,
-    name: `${friendInfo.first_name ?? '[unknown]'} ${
-      friendInfo.last_name ?? '[unknown]'
+    name: `${friendInfo.firstName ?? '[unknown]'} ${
+      friendInfo.lastName ?? '[unknown]'
     }`,
   }));
 
@@ -231,7 +231,7 @@ export const getFriendsWorksheets = async (
   winston.info('Getting worksheets of friends');
   const friendWorksheets = await prisma.worksheetCourses.findMany({
     where: {
-      net_id: {
+      netId: {
         in: friendNetIds,
       },
     },
@@ -250,8 +250,8 @@ export const getFriendsWorksheets = async (
 
   const friendNames = friendInfos.map((friendInfo) => ({
     netId: friendInfo.netId,
-    name: `${friendInfo.first_name ?? '[unknown]'} ${
-      friendInfo.last_name ?? '[unknown]'
+    name: `${friendInfo.firstName ?? '[unknown]'} ${
+      friendInfo.lastName ?? '[unknown]'
     }`,
   }));
 
@@ -260,17 +260,12 @@ export const getFriendsWorksheets = async (
   for (const nameRecord of friendNames)
     friendNameMap[nameRecord.netId] = { name: nameRecord.name };
 
-  // Map netId to worksheets (list of [season, oci_id, worksheet_number])
+  // Map netId to worksheets (list of [season, ociId, worksheetNumber])
   const worksheetsByFriend: {
     [netId: string]: [string, string, string][];
   } = {};
   friendWorksheets.forEach(
-    ({
-      net_id: friendNetId,
-      oci_id: ociId,
-      season,
-      worksheet_number: worksheetNumber,
-    }) => {
+    ({ netId: friendNetId, ociId, season, worksheetNumber }) => {
       if (friendNetId in worksheetsByFriend) {
         worksheetsByFriend[friendNetId].push([
           String(season),
@@ -301,8 +296,8 @@ export const getNames = async (
 
   const allNames = allNameRecords.map((nameRecord) => ({
     netId: nameRecord.netId,
-    first: nameRecord.first_name,
-    last: nameRecord.last_name,
+    first: nameRecord.firstName,
+    last: nameRecord.lastName,
     college: nameRecord.college,
   }));
   res.status(200).json(allNames);

--- a/api/src/user/user.handlers.ts
+++ b/api/src/user/user.handlers.ts
@@ -12,8 +12,8 @@ import { prisma } from '../config';
 const ToggleBookmarkReqBodySchema = z.object({
   action: z.union([z.literal('add'), z.literal('remove')]),
   season: z.string(),
-  oci_id: z.number(),
-  worksheet_number: z.number(),
+  ociId: z.number(),
+  worksheetNumber: z.number(),
 });
 
 /**
@@ -36,12 +36,7 @@ export const toggleBookmark = async (
     return;
   }
 
-  const {
-    action,
-    season,
-    oci_id: ociId,
-    worksheet_number: worksheetNumber,
-  } = bodyParseRes.data;
+  const { action, season, ociId, worksheetNumber } = bodyParseRes.data;
 
   if (action === 'add') {
     // Add a bookmarked course
@@ -50,10 +45,10 @@ export const toggleBookmark = async (
     );
     await prisma.worksheetCourses.create({
       data: {
-        net_id: netId,
-        oci_id: ociId,
+        netId,
+        ociId,
         season: parseInt(season, 10),
-        worksheet_number: worksheetNumber,
+        worksheetNumber,
       },
     });
   } else {
@@ -63,10 +58,10 @@ export const toggleBookmark = async (
     );
     await prisma.worksheetCourses.deleteMany({
       where: {
-        net_id: netId,
-        oci_id: ociId,
+        netId,
+        ociId,
         season: parseInt(season, 10),
-        worksheet_number: worksheetNumber,
+        worksheetNumber,
       },
     });
   }
@@ -100,7 +95,7 @@ export const getUserWorksheet = async (
   winston.info(`Getting worksheets for user ${netId}`);
   const worksheets = await prisma.worksheetCourses.findMany({
     where: {
-      net_id: netId,
+      netId,
     },
   });
 
@@ -112,8 +107,8 @@ export const getUserWorksheet = async (
     school: studentProfile?.school,
     data: worksheets.map((course) => [
       String(course.season),
-      String(course.oci_id),
-      String(course.worksheet_number),
+      String(course.ociId),
+      String(course.worksheetNumber),
     ]),
   });
 };

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,8 +285,8 @@ TODO: rename this to `/api/catalog` and remove `.json`?
 - Body:
   - `action`: `"add" | "remove"`
   - `season`: `string`
-  - `oci_id`: `number`
-  - `worksheet_number`: `number`
+  - `ociId`: `number`
+  - `worksheetNumber`: `number`
 
 #### Response
 

--- a/frontend/src/components/Worksheet/WorksheetToggleButton.tsx
+++ b/frontend/src/components/Worksheet/WorksheetToggleButton.tsx
@@ -111,8 +111,8 @@ function WorksheetToggleButton({
           {
             action: addRemove,
             season: seasonCode,
-            oci_id: crn,
-            worksheet_number: parseInt(selectedWorksheet, 10),
+            ociId: crn,
+            worksheetNumber: parseInt(selectedWorksheet, 10),
           },
           {
             withCredentials: true,


### PR DESCRIPTION
This is a one-off migration. Otherwise the mix of `net_id` and `netId` is just going to cause more pain int the future.