### PR TITLE
fix: hide tutorial when user got redirected to challenge

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,12 @@ function App() {
   // Handle whether or not to open tutorial
   useEffect(() => {
     if (!isMobile && !isTablet && isLoggedIn && !shownTutorial) {
-      if (location.pathname === '/catalog') setIsTutorialOpen(true);
+      if (location.pathname === '/catalog') {
+        setIsTutorialOpen(true);
+      } else if (location.pathname !== '/worksheet') {
+        // This can happen if the user got redirected to /challenge
+        setIsTutorialOpen(false);
+      }
     } else {
       setIsTutorialOpen(false);
     }


### PR DESCRIPTION
Fix a long-standing Sentry exception (which generated 90% of our user reports).

```
TypeError
Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
```

This happens because when the router redirects, the underlying DOM has changed but the tutorial keeps showing.

To test (reproduce) this:

1. Disables evals for yourself (needs DB access) but keep yourself signed in.
2. Go to `/catalog`.
3. Delete `shownTutorial` in your local storage or set it to `false`.
4. Refresh the page.
5. When the tutorial shows, click "Next" a few times. And boom.