### PR TITLE
fix: cycle gcal event colorId

### DIFF
--- a/frontend/src/utilities/calendar.ts
+++ b/frontend/src/utilities/calendar.ts
@@ -139,7 +139,7 @@ function toGCalEvent({
       timeZone: 'America/New_York',
     },
     recurrence,
-    colorId: (colorIndex + 1).toString(),
+    colorId: ((colorIndex % 11) + 1).toString(),
     description,
     location,
   };

--- a/frontend/src/utilities/calendar.ts
+++ b/frontend/src/utilities/calendar.ts
@@ -139,6 +139,7 @@ function toGCalEvent({
       timeZone: 'America/New_York',
     },
     recurrence,
+    // Cycle the ID because each calendar only has a fixed set of colors
     colorId: ((colorIndex % 11) + 1).toString(),
     description,
     location,


### PR DESCRIPTION
the colorid will no longer go to infinity, so it will always be valid.
