### PR TITLE
fix: restore to previous catalog view mode when resizing to desktop (instead of staying in grid)

### DIFF
--- a/frontend/src/components/Search/Results.tsx
+++ b/frontend/src/components/Search/Results.tsx
@@ -16,6 +16,7 @@ import styles from './Results.module.css';
 import NoCoursesFound from '../../images/no_courses_found.svg';
 
 import WindowScroller from './WindowScroller';
+import { useSessionStorageState } from '../../utilities/browserStorage';
 import type { Listing } from '../../utilities/common';
 import { toSeasonString } from '../../utilities/course';
 
@@ -40,8 +41,6 @@ const getColWidth = (calculated: number, min = 0, max = 1000000) =>
 /**
  * Renders the infinite list of search results for both catalog and worksheet
  * @prop data - array | that holds the search results
- * @prop isListView - boolean | determines display format (list or grid)
- * @prop setIsListView - function | changes display format
  * @prop loading - boolean | Is the search query finished?
  * @prop multiSeasons - boolean | are we displaying courses across multiple seasons
  * @prop numFriends = object | holds a list of each friend taking a specific course
@@ -50,16 +49,12 @@ const getColWidth = (calculated: number, min = 0, max = 1000000) =>
 
 function Results({
   data,
-  isListView,
-  setIsListView,
   loading = false,
   multiSeasons = false,
   numFriends,
   page = 'catalog',
 }: {
   readonly data: Listing[];
-  readonly isListView: boolean;
-  readonly setIsListView: (isList: boolean) => void;
   readonly loading?: boolean;
   readonly multiSeasons?: boolean;
   readonly numFriends: { [seasonCodeCrn: string]: string[] };
@@ -72,6 +67,10 @@ function Results({
     isTablet,
     isLgDesktop,
   } = useWindowDimensions();
+  const [isListView, setIsListView] = useSessionStorageState(
+    'isListView',
+    true,
+  );
 
   // State that holds width of the row for list view
   const [rowWidth, setRowWidth] = useState(0);
@@ -171,8 +170,10 @@ function Results({
         )}
       </div>
     );
-  } else if (!isListView) {
-    // Not list -> use grid view
+  } else if (!isListView || isMobile) {
+    // Not list or on mobile -> use grid view
+    // Do not force entering grid mode on mobile, so that when resizing the
+    // window, the view can still be restored to list view
     resultsListing = (
       <WindowScroller>
         {({ ref, outerRef, style }) => (

--- a/frontend/src/components/Worksheet/WorksheetList.tsx
+++ b/frontend/src/components/Worksheet/WorksheetList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Col, Row } from 'react-bootstrap';
 
 import { sortCourses } from '../../utilities/course';
@@ -11,7 +11,6 @@ import Results from '../Search/Results';
  */
 
 function WorksheetList() {
-  const [isListView, setIsListView] = useState(true);
   const { courses, worksheetLoading } = useWorksheet();
 
   const {
@@ -37,8 +36,6 @@ function WorksheetList() {
           <div className="d-flex justify-content-center">
             <Results
               data={WorksheetData}
-              isListView={isListView}
-              setIsListView={setIsListView}
               loading={worksheetLoading}
               multiSeasons={false}
               numFriends={numFriends}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -9,18 +9,11 @@ import styles from './Search.module.css';
 import MobileSearchForm from '../components/Search/MobileSearchForm';
 import Results from '../components/Search/Results';
 import { useWindowDimensions } from '../contexts/windowDimensionsContext';
-import { useSessionStorageState } from '../utilities/browserStorage';
 import { useSearch } from '../contexts/searchContext';
 
 function Search() {
   // Fetch current device
   const { isMobile } = useWindowDimensions();
-
-  // Way to display results
-  const [isListView, setIsListView] = useSessionStorageState(
-    'isListView',
-    !isMobile,
-  );
 
   // Get search context data
   const { coursesLoading, searchData, multiSeasons, numFriends } = useSearch();
@@ -50,11 +43,6 @@ function Search() {
     }
   }, [coursesLoading, doneInitialScroll, scrollToResults]);
 
-  // Switch to grid view if mobile
-  useEffect(() => {
-    if (isMobile && isListView) setIsListView(false);
-  }, [isMobile, isListView, setIsListView]);
-
   // TODO: add state if courseLoadError is present
   return (
     <div className={styles.search_base}>
@@ -79,8 +67,6 @@ function Search() {
           <Element name="catalog" className="d-flex justify-content-center">
             <Results
               data={searchData}
-              isListView={isListView}
-              setIsListView={setIsListView}
               loading={coursesLoading}
               multiSeasons={multiSeasons}
               numFriends={numFriends}


### PR DESCRIPTION
Fix https://github.com/coursetable/coursetable/issues/1444