### PR TITLE
fix: consistently use the currently viewed worksheet to calculate conflicts

### DIFF
--- a/frontend/src/Globals.tsx
+++ b/frontend/src/Globals.tsx
@@ -68,13 +68,15 @@ function Globals({ children }: { readonly children: React.ReactNode }) {
           <UserProvider>
             <FerryProvider>
               <WindowDimensionsProvider>
-                <SearchProvider>
-                  <WorksheetProvider>
+                {/* SearchProvider must be inside WorksheetProvider because the
+                  former depends on the currently viewed worksheet */}
+                <WorksheetProvider>
+                  <SearchProvider>
                     <ThemeProvider>
                       <div id="base">{children}</div>
                     </ThemeProvider>
-                  </WorksheetProvider>
-                </SearchProvider>
+                  </SearchProvider>
+                </WorksheetProvider>
                 {/* TODO: style toasts with bootstrap using https://fkhadra.github.io/react-toastify/how-to-style/ */}
                 <ToastContainer toastClassName="rounded" />
               </WindowDimensionsProvider>

--- a/frontend/src/components/Search/CourseConflictIcon.tsx
+++ b/frontend/src/components/Search/CourseConflictIcon.tsx
@@ -4,6 +4,7 @@ import { OverlayTrigger, Tooltip, Fade } from 'react-bootstrap';
 import { MdErrorOutline } from 'react-icons/md';
 import { useUser } from '../../contexts/userContext';
 import { useWorksheetInfo } from '../../contexts/ferryContext';
+import { useWorksheet } from '../../contexts/worksheetContext';
 import type { Listing } from '../../utilities/common';
 import {
   checkConflict,
@@ -17,22 +18,28 @@ import {
  */
 function CourseConflictIcon({ course }: { readonly course: Listing }) {
   const { user } = useUser();
-
-  const inWorksheet = isInWorksheet(
-    course.season_code,
-    course.crn,
-    0,
-    user.worksheet,
-  );
+  const { worksheetNumber } = useWorksheet();
 
   // Fetch listing info for each listing in user's worksheet
-  const { data } = useWorksheetInfo(user.worksheet, course.season_code);
+  const { data } = useWorksheetInfo(
+    user.worksheet,
+    course.season_code,
+    worksheetNumber,
+  );
 
   // Update conflict status whenever the user's worksheet changes
   const conflicts = useMemo(() => {
+    const inWorksheet = isInWorksheet(
+      course.season_code,
+      course.crn,
+      worksheetNumber,
+      user.worksheet,
+    );
+    // If the course is in the worksheet, we never report a conflict
+    if (inWorksheet) return [];
     if (course.times_summary === 'TBA') return [];
     return checkConflict(data, course);
-  }, [course, data]);
+  }, [course, data, user.worksheet, worksheetNumber]);
 
   // Update conflict status whenever the user's worksheet changes
   const crossListed = useMemo(
@@ -42,31 +49,25 @@ function CourseConflictIcon({ course }: { readonly course: Listing }) {
 
   return (
     // Smooth fade in and out transition
-    <Fade in={!inWorksheet && conflicts.length > 0}>
+    <Fade in={conflicts.length > 0}>
       <div>
         <OverlayTrigger
           placement="top"
-          overlay={(props) =>
-            // Render if this course isn't in the worksheet and there is a
-            // conflict
-            !inWorksheet && conflicts.length > 0 ? (
-              <Tooltip {...props} id="conflict-icon-button-tooltip">
-                <small style={{ fontWeight: 500 }}>
-                  Conflicts with: <br />
-                  {conflicts.map((x) => x.course_code).join(', ')} <br />
-                </small>
-                {crossListed !== false ? (
-                  // Show only if the class is cross-listed with another class
-                  // in the worksheet
-                  <small>(cross-listed with {crossListed})</small>
-                ) : (
-                  ''
-                )}
-              </Tooltip>
-            ) : (
-              <div />
-            )
-          }
+          overlay={(props) => (
+            <Tooltip {...props} id="conflict-icon-button-tooltip">
+              <small style={{ fontWeight: 500 }}>
+                Conflicts with: <br />
+                {conflicts.map((x) => x.course_code).join(', ')} <br />
+              </small>
+              {crossListed !== false ? (
+                // Show only if the class is cross-listed with another class
+                // in the worksheet
+                <small>(cross-listed with {crossListed})</small>
+              ) : (
+                ''
+              )}
+            </Tooltip>
+          )}
         >
           <MdErrorOutline color="#fc4103" />
         </OverlayTrigger>

--- a/frontend/src/contexts/searchContext.tsx
+++ b/frontend/src/contexts/searchContext.tsx
@@ -13,6 +13,7 @@ import {
 } from '../utilities/common';
 import { useSessionStorageState } from '../utilities/browserStorage';
 import { useCourseData, useWorksheetInfo, seasons } from './ferryContext';
+import { useWorksheet } from './worksheetContext';
 import {
   skillsAreasColors,
   skillsAreas,
@@ -20,6 +21,7 @@ import {
   schools,
 } from '../utilities/constants';
 import {
+  isInWorksheet,
   checkConflict,
   getDayTimes,
   getEnrolled,
@@ -316,7 +318,13 @@ export function SearchProvider({
   // (if multiple seasons are queried, the season is indicated)
   const multiSeasons = processedSeasons.length !== 1;
 
-  const { data: worksheetInfo } = useWorksheetInfo(user.worksheet);
+  const { worksheetNumber } = useWorksheet();
+
+  const { data: worksheetInfo } = useWorksheetInfo(
+    user.worksheet,
+    null,
+    worksheetNumber,
+  );
 
   // Filtered and sorted courses
   const searchData = useMemo(() => {
@@ -400,6 +408,12 @@ export function SearchProvider({
       if (
         hideConflicting.value &&
         listing.times_summary !== 'TBA' &&
+        !isInWorksheet(
+          listing.season_code,
+          listing.crn,
+          worksheetNumber,
+          user.worksheet,
+        ) &&
         checkConflict(worksheetInfo, listing).length > 0
       )
         return false;
@@ -499,6 +513,8 @@ export function SearchProvider({
     processedNumBounds,
     hideCancelled.value,
     hideConflicting.value,
+    worksheetNumber,
+    user.worksheet,
     worksheetInfo,
     hideDiscussionSections.value,
     hideFirstYearSeminars.value,


### PR DESCRIPTION
Currently we always use the main worksheet, which looks non-ideal because I may be bluebooking using another worksheet.