### PR TITLE
refactor: use CSS instead of JS to calcalate column width

### DIFF
--- a/frontend/src/components/Search/Results.module.css
+++ b/frontend/src/components/Search/Results.module.css
@@ -1,5 +1,42 @@
-.resultsContainerMaxWidth {
+.resultsContainer {
   width: 100%;
+
+  --width-total: min(1600px, 100vw);
+  --width-col-season: 0px;
+  --width-col-code: 90px;
+  --width-col-overall: 82px;
+  --width-col-workload: 82px;
+  --width-col-prof-rating: 36px;
+  --width-col-enroll: 40px;
+  --width-col-friends: 60px;
+  --width-padding: 43px;
+  --width-extra: calc(
+    var(--width-total) - var(--width-col-season) - var(--width-col-code) -
+      var(--width-col-overall) - var(--width-col-workload) -
+      var(--width-col-prof-rating) - var(--width-col-enroll) -
+      var(--width-col-friends) - var(--width-padding)
+  );
+  --width-col-prof: calc(var(--width-extra) / 7 + var(--width-col-prof-rating));
+  --width-col-skill-area: clamp(40px, calc(var(--width-extra) / 8), 126px);
+  --width-col-meet: clamp(60px, calc(var(--width-extra) / 6), 170px);
+  --width-col-loc: max(30px, var(--width-extra) / 13);
+  --width-col-title: calc(
+    var(--width-extra) - var(--width-col-prof) - var(--width-col-skill-area) -
+      var(--width-col-meet) - var(--width-col-loc) - 10px
+  );
+}
+
+.resultsContainer.resultsMultiSeasons {
+  --width-col-season: 60px;
+}
+
+@media (width >= 1320px) {
+  .resultsContainer {
+    --width-col-code: 110px;
+    --width-col-overall: 92px;
+    --width-col-workload: 92px;
+    --width-col-prof-rating: 40px;
+  }
 }
 
 .gridRow {

--- a/frontend/src/components/Search/Results.tsx
+++ b/frontend/src/components/Search/Results.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { Row, Spinner } from 'react-bootstrap';
 import { FixedSizeList } from 'react-window';
@@ -21,10 +21,6 @@ import { toSeasonString } from '../../utilities/course';
 
 import { useWorksheet } from '../../contexts/worksheetContext';
 
-// Function to calculate column width within a max and min
-const getColWidth = (calculated: number, min = 0, max = 1000000) =>
-  Math.max(Math.min(calculated, max), min);
-
 /**
  * Renders the infinite list of search results for both catalog and worksheet
  * @prop data - array | that holds the search results
@@ -46,75 +42,13 @@ function Results({
   readonly page?: 'catalog' | 'worksheet';
 }) {
   // Fetch current device
-  const {
-    width: windowWidth,
-    isMobile,
-    isTablet,
-    isLgDesktop,
-  } = useWindowDimensions();
+  const { isMobile, isTablet, isLgDesktop } = useWindowDimensions();
   const [isListView, setIsListView] = useSessionStorageState(
     'isListView',
     true,
   );
 
-  // State that holds width of the row for list view
-  const [rowWidth, setRowWidth] = useState(0);
-
   const { curSeason } = useWorksheet();
-
-  // Ref to get row width
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    // Set row width
-    if (ref.current) setRowWidth(ref.current.offsetWidth);
-  }, [setRowWidth, windowWidth]);
-
-  // Spacing for each column in list view
-  const COL_SPACING = useMemo(() => {
-    const TEMP_COL_SPACING = {
-      SZN_WIDTH: 60,
-      CODE_WIDTH: isLgDesktop ? 110 : 90,
-      RATE_OVERALL_WIDTH: isLgDesktop ? 92 : 82,
-      RATE_WORKLOAD_WIDTH: isLgDesktop ? 92 : 82,
-      RATE_PROF_WIDTH: isLgDesktop ? 40 : 36,
-      ENROLL_WIDTH: 40,
-      FRIENDS_WIDTH: 60,
-      PADDING: 43,
-
-      PROF_WIDTH: 0,
-      SA_WIDTH: 0,
-      MEET_WIDTH: 0,
-      LOC_WIDTH: 0,
-      TITLE_WIDTH: 0,
-    };
-
-    const EXTRA =
-      rowWidth -
-      (multiSeasons ? TEMP_COL_SPACING.SZN_WIDTH : 0) -
-      TEMP_COL_SPACING.CODE_WIDTH -
-      TEMP_COL_SPACING.ENROLL_WIDTH -
-      TEMP_COL_SPACING.FRIENDS_WIDTH -
-      TEMP_COL_SPACING.RATE_OVERALL_WIDTH -
-      TEMP_COL_SPACING.RATE_WORKLOAD_WIDTH -
-      TEMP_COL_SPACING.RATE_PROF_WIDTH -
-      TEMP_COL_SPACING.PADDING;
-
-    TEMP_COL_SPACING.PROF_WIDTH =
-      getColWidth(EXTRA / 7, undefined, undefined) +
-      TEMP_COL_SPACING.RATE_PROF_WIDTH;
-    TEMP_COL_SPACING.SA_WIDTH = getColWidth(EXTRA / 8, 40, 126);
-    TEMP_COL_SPACING.MEET_WIDTH = getColWidth(EXTRA / 6, 60, 170);
-    TEMP_COL_SPACING.LOC_WIDTH = getColWidth(EXTRA / 13, 30, undefined);
-    TEMP_COL_SPACING.TITLE_WIDTH =
-      EXTRA -
-      TEMP_COL_SPACING.PROF_WIDTH -
-      TEMP_COL_SPACING.SA_WIDTH -
-      TEMP_COL_SPACING.MEET_WIDTH -
-      TEMP_COL_SPACING.LOC_WIDTH -
-      10;
-
-    return TEMP_COL_SPACING;
-  }, [rowWidth, multiSeasons, isLgDesktop]);
 
   // Number of columns to use in grid view
   const numCols = isMobile ? 1 : isTablet ? 2 : 3;
@@ -211,7 +145,6 @@ function Results({
                 course={data[index]!}
                 multiSeasons={multiSeasons}
                 isFirst={index === 0}
-                COL_SPACING={COL_SPACING}
               />
             )}
           </FixedSizeList>
@@ -221,11 +154,14 @@ function Results({
   }
 
   return (
-    <div className={styles.resultsContainerMaxWidth}>
+    <div
+      className={clsx(
+        styles.resultsContainer,
+        multiSeasons && styles.resultsMultiSeasons,
+      )}
+    >
       {!isMobile && (
         <ResultsHeaders
-          ref={ref}
-          COL_SPACING={COL_SPACING}
           multiSeasons={multiSeasons}
           page={page}
           isListView={isListView}

--- a/frontend/src/components/Search/ResultsCols.module.css
+++ b/frontend/src/components/Search/ResultsCols.module.css
@@ -1,0 +1,51 @@
+.seasonCol {
+  width: var(--width-col-season);
+  padding-left: 15px;
+}
+
+.codeCol {
+  width: var(--width-col-code);
+  padding-left: 15px;
+}
+
+.codeCol.multiSeasons {
+  padding-left: 0;
+}
+
+.titleCol {
+  width: var(--width-col-title);
+}
+
+.overallCol {
+  white-space: nowrap;
+  width: var(--width-col-overall);
+}
+
+.workloadCol {
+  white-space: nowrap;
+  width: var(--width-col-workload);
+}
+
+.profCol {
+  width: var(--width-col-prof);
+}
+
+.meetCol {
+  width: var(--width-col-meet);
+}
+
+.locCol {
+  width: var(--width-col-loc);
+}
+
+.enrollCol {
+  width: var(--width-col-enroll);
+}
+
+.friendsCol {
+  width: var(--width-col-friends);
+}
+
+.skillAreaCol {
+  width: var(--width-col-skill-area);
+}

--- a/frontend/src/components/Search/ResultsHeaders.tsx
+++ b/frontend/src/components/Search/ResultsHeaders.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, forwardRef } from 'react';
+import React, { useMemo } from 'react';
 import { Col, Row, Tooltip, OverlayTrigger } from 'react-bootstrap';
 import { FaBars, FaTh } from 'react-icons/fa';
 import clsx from 'clsx';
@@ -9,20 +9,21 @@ import { SurfaceComponent } from '../Typography';
 import { type SortKeys, sortByOptions } from '../../contexts/searchContext';
 import { useWindowDimensions } from '../../contexts/windowDimensionsContext';
 import styles from './ResultsHeaders.module.css';
+import colStyles from './ResultsCols.module.css';
 
 function HeaderCol({
-  style,
+  className,
   children,
   tooltip,
   sortOption,
 }: {
-  readonly style: React.CSSProperties;
+  readonly className: string | undefined;
   readonly children: React.ReactNode;
   readonly tooltip?: string | JSX.Element;
   readonly sortOption?: SortKeys;
 }) {
   return (
-    <div className={styles.resultsHeader} style={style}>
+    <div className={clsx(className, styles.resultsHeader)}>
       {tooltip ? (
         <OverlayTrigger
           placement="bottom"
@@ -44,63 +45,20 @@ function HeaderCol({
   );
 }
 
-function ResultsHeaders(
-  {
-    COL_SPACING,
-    multiSeasons,
-    page,
-    isListView,
-    setIsListView,
-    numResults,
-  }: {
-    // This can be more exact, but I'm too lazy to type everything out :)
-    readonly COL_SPACING: { [prop: string]: number };
-    readonly multiSeasons: boolean;
-    readonly page: 'catalog' | 'worksheet';
-    readonly isListView: boolean;
-    readonly setIsListView: (isList: boolean) => void;
-    readonly numResults: number;
-  },
-  ref: React.Ref<HTMLDivElement>,
-) {
+function ResultsHeaders({
+  multiSeasons,
+  page,
+  isListView,
+  setIsListView,
+  numResults,
+}: {
+  readonly multiSeasons: boolean;
+  readonly page: 'catalog' | 'worksheet';
+  readonly isListView: boolean;
+  readonly setIsListView: (isList: boolean) => void;
+  readonly numResults: number;
+}) {
   const { isTablet, isLgDesktop, isSmDesktop } = useWindowDimensions();
-
-  // Column width styles
-  const sznStyle: React.CSSProperties = {
-    width: `${COL_SPACING.SZN_WIDTH}px`,
-    paddingLeft: '15px',
-  };
-  const codeStyle: React.CSSProperties = {
-    width: `${COL_SPACING.CODE_WIDTH}px`,
-    paddingLeft: !multiSeasons ? '15px' : '0px',
-  };
-  const titleStyle: React.CSSProperties = {
-    width: `${COL_SPACING.TITLE_WIDTH}px`,
-  };
-  const rateOverallStyle: React.CSSProperties = {
-    whiteSpace: 'nowrap',
-    width: `${COL_SPACING.RATE_OVERALL_WIDTH}px`,
-  };
-  const rateWorkloadStyle: React.CSSProperties = {
-    whiteSpace: 'nowrap',
-    width: `${COL_SPACING.RATE_WORKLOAD_WIDTH}px`,
-  };
-  const profStyle: React.CSSProperties = {
-    width: `${COL_SPACING.PROF_WIDTH}px`,
-  };
-  const meetStyle: React.CSSProperties = {
-    width: `${COL_SPACING.MEET_WIDTH}px`,
-  };
-  const locStyle: React.CSSProperties = {
-    width: `${COL_SPACING.LOC_WIDTH}px`,
-  };
-  const enrollStyle: React.CSSProperties = {
-    width: `${COL_SPACING.ENROLL_WIDTH}px`,
-  };
-  const friendsStyle: React.CSSProperties = {
-    width: `${COL_SPACING.FRIENDS_WIDTH}px`,
-  };
-  const saStyle: React.CSSProperties = { width: `${COL_SPACING.SA_WIDTH}px` };
 
   const navbarHeight = useMemo(() => {
     if (page === 'catalog') {
@@ -122,7 +80,6 @@ function ResultsHeaders(
       >
         {/* Column Headers */}
         <Row
-          ref={ref}
           className={clsx(
             'mx-auto pl-4 pr-2',
             isLgDesktop ? 'py-2' : 'py-1',
@@ -153,20 +110,25 @@ function ResultsHeaders(
           </div>
           {isListView ? (
             <>
-              {multiSeasons && <HeaderCol style={sznStyle}>Season</HeaderCol>}
+              {multiSeasons && (
+                <HeaderCol className={colStyles.seasonCol}>Season</HeaderCol>
+              )}
               <HeaderCol
-                style={codeStyle}
+                className={clsx(
+                  colStyles.codeCol,
+                  multiSeasons && colStyles.multiSeasons,
+                )}
                 tooltip="Course Code and Section"
                 sortOption="course_code"
               >
                 Code
               </HeaderCol>
-              <HeaderCol style={titleStyle} sortOption="title">
+              <HeaderCol className={colStyles.titleCol} sortOption="title">
                 Title
               </HeaderCol>
               <div className="d-flex">
                 <HeaderCol
-                  style={rateOverallStyle}
+                  className={colStyles.overallCol}
                   tooltip={
                     <span>
                       Average Course Rating
@@ -181,7 +143,7 @@ function ResultsHeaders(
                   Overall
                 </HeaderCol>
                 <HeaderCol
-                  style={rateWorkloadStyle}
+                  className={colStyles.workloadCol}
                   tooltip={
                     <span>
                       Average Workload Rating
@@ -196,7 +158,7 @@ function ResultsHeaders(
                   Work
                 </HeaderCol>
                 <HeaderCol
-                  style={profStyle}
+                  className={colStyles.profCol}
                   tooltip={
                     <span>
                       Average Professor Rating and Names
@@ -211,7 +173,7 @@ function ResultsHeaders(
                 </HeaderCol>
               </div>
               <HeaderCol
-                style={enrollStyle}
+                className={colStyles.enrollCol}
                 tooltip={
                   multiSeasons ? (
                     <span>
@@ -234,9 +196,11 @@ function ResultsHeaders(
               >
                 #
               </HeaderCol>
-              <HeaderCol style={saStyle}>Skills/Areas</HeaderCol>
+              <HeaderCol className={colStyles.skillAreaCol}>
+                Skills/Areas
+              </HeaderCol>
               <HeaderCol
-                style={meetStyle}
+                className={colStyles.meetCol}
                 tooltip={
                   <span>
                     Days of the Week and Times
@@ -248,11 +212,14 @@ function ResultsHeaders(
               >
                 Meets
               </HeaderCol>
-              <HeaderCol style={locStyle} sortOption="locations_summary">
+              <HeaderCol
+                className={colStyles.locCol}
+                sortOption="locations_summary"
+              >
                 Location
               </HeaderCol>
               <HeaderCol
-                style={friendsStyle}
+                className={colStyles.friendsCol}
                 tooltip="Number of friends shopping this course"
                 sortOption="friend"
               >
@@ -275,4 +242,4 @@ function ResultsHeaders(
   );
 }
 
-export default forwardRef(ResultsHeaders);
+export default ResultsHeaders;

--- a/frontend/src/components/Search/ResultsItem.module.css
+++ b/frontend/src/components/Search/ResultsItem.module.css
@@ -109,6 +109,11 @@
   line-height: 1.5;
 }
 
+.profRating {
+  white-space: nowrap;
+  min-width: var(--width-col-prof-rating);
+}
+
 .tag {
   margin: 1px;
   font-size: 13px;

--- a/frontend/src/components/Search/ResultsItem.tsx
+++ b/frontend/src/components/Search/ResultsItem.tsx
@@ -20,6 +20,7 @@ import SkillBadge from '../SkillBadge';
 import { TextComponent, InfoPopover, RatingBubble } from '../Typography';
 
 import styles from './ResultsItem.module.css';
+import colStyles from './ResultsCols.module.css';
 import {
   getEnrolled,
   getOverallRatings,
@@ -47,15 +48,12 @@ function ResultsItem({
   multiSeasons,
   isFirst,
   isOdd,
-  COL_SPACING,
   style,
 }: {
   readonly course: Listing;
   readonly multiSeasons: boolean;
   readonly isFirst: boolean;
   readonly isOdd: boolean;
-  // This can be more exact, but I'm too lazy to type everything out :)
-  readonly COL_SPACING: { [prop: string]: number };
   readonly style?: React.CSSProperties;
 }) {
   const [, setSearchParams] = useSearchParams();
@@ -88,47 +86,6 @@ function ResultsItem({
 
   // Is the current course in the worksheet?
   const [courseInWorksheet, setCourseInWorksheet] = useState(false);
-
-  // Column width styles
-  const sznStyle: React.CSSProperties = {
-    width: `${COL_SPACING.SZN_WIDTH}px`,
-    paddingLeft: '15px',
-  };
-  const codeStyle: React.CSSProperties = {
-    width: `${COL_SPACING.CODE_WIDTH}px`,
-    paddingLeft: !multiSeasons ? '15px' : '0px',
-  };
-  const titleStyle: React.CSSProperties = {
-    width: `${COL_SPACING.TITLE_WIDTH}px`,
-  };
-  const rateOverallStyle: React.CSSProperties = {
-    whiteSpace: 'nowrap',
-    width: `${COL_SPACING.RATE_OVERALL_WIDTH}px`,
-  };
-  const rateWorkloadStyle: React.CSSProperties = {
-    whiteSpace: 'nowrap',
-    width: `${COL_SPACING.RATE_WORKLOAD_WIDTH}px`,
-  };
-  const rateProfStyle: React.CSSProperties = {
-    whiteSpace: 'nowrap',
-    minWidth: `${COL_SPACING.RATE_PROF_WIDTH}px`,
-  };
-  const profStyle: React.CSSProperties = {
-    width: `${COL_SPACING.PROF_WIDTH}px`,
-  };
-  const meetStyle: React.CSSProperties = {
-    width: `${COL_SPACING.MEET_WIDTH}px`,
-  };
-  const locStyle: React.CSSProperties = {
-    width: `${COL_SPACING.LOC_WIDTH}px`,
-  };
-  const enrollStyle: React.CSSProperties = {
-    width: `${COL_SPACING.ENROLL_WIDTH}px`,
-  };
-  const friendsStyle: React.CSSProperties = {
-    width: `${COL_SPACING.FRIENDS_WIDTH}px`,
-  };
-  const saStyle: React.CSSProperties = { width: `${COL_SPACING.SA_WIDTH}px` };
 
   const [subjectCode, courseCode] = course.course_code.split(' ') as [
     string,
@@ -166,7 +123,7 @@ function ResultsItem({
       >
         {/* Season */}
         {multiSeasons && (
-          <div style={sznStyle} className="d-flex">
+          <div className={clsx('d-flex', colStyles.seasonCol)}>
             <OverlayTrigger
               placement="top"
               overlay={(props) => (
@@ -193,33 +150,37 @@ function ResultsItem({
         )}
         {/* Course Code */}
         <div
-          style={codeStyle}
-          className={clsx(styles.ellipsisText, 'font-weight-bold')}
+          className={clsx(
+            colStyles.codeCol,
+            multiSeasons && colStyles.multiSeasons,
+          )}
         >
-          <OverlayTrigger
-            placement="top"
-            overlay={(props) => {
-              const subjectName = subjects[subjectCode];
-              if (!subjectName) {
-                Sentry.captureException(
-                  new Error(`Subject ${subjectCode} has no label`),
+          <div className={clsx(styles.ellipsisText, 'font-weight-bold')}>
+            <OverlayTrigger
+              placement="top"
+              overlay={(props) => {
+                const subjectName = subjects[subjectCode];
+                if (!subjectName) {
+                  Sentry.captureException(
+                    new Error(`Subject ${subjectCode} has no label`),
+                  );
+                }
+                return (
+                  <Tooltip id="button-tooltip" {...props}>
+                    <small>{subjectName ?? '[unknown]'}</small>
+                  </Tooltip>
                 );
-              }
-              return (
-                <Tooltip id="button-tooltip" {...props}>
-                  <small>{subjectName ?? '[unknown]'}</small>
-                </Tooltip>
-              );
-            }}
-          >
-            <span>{subjectCode}</span>
-          </OverlayTrigger>{' '}
-          {courseCode}
-          <TextComponent type="secondary">
-            {course.section
-              ? ` ${course.section.length > 1 ? '' : '0'}${course.section}`
-              : ''}
-          </TextComponent>
+              }}
+            >
+              <span>{subjectCode}</span>
+            </OverlayTrigger>{' '}
+            {courseCode}
+            <TextComponent type="secondary">
+              {course.section
+                ? ` ${course.section.length > 1 ? '' : '0'}${course.section}`
+                : ''}
+            </TextComponent>
+          </div>
         </div>
         <OverlayTrigger
           placement="right"
@@ -246,32 +207,31 @@ function ResultsItem({
           )}
         >
           {/* Course Title */}
-          <div style={titleStyle}>
+          <div className={colStyles.titleCol}>
             <div className={styles.ellipsisText}>{course.title}</div>
           </div>
         </OverlayTrigger>
         <div className="d-flex">
-          {/* Overall Rating */}
-          <RatingBubble
-            className={styles.ratingCell}
-            rating={getOverallRatings(course, 'stat')}
-            colorMap={ratingColormap}
-            style={rateOverallStyle}
-          >
-            {getOverallRatings(course, 'display')}
-          </RatingBubble>
-          {/* Workload Rating */}
-          <RatingBubble
-            className={styles.ratingCell}
-            rating={getWorkloadRatings(course, 'stat')}
-            colorMap={workloadColormap}
-            style={rateWorkloadStyle}
-          >
-            {getWorkloadRatings(course, 'display')}
-          </RatingBubble>
-          {/* Professor Rating & Course Professors */}
-          <div style={profStyle} className="d-flex align-items-center">
-            <div style={rateProfStyle} className="mr-2 h-100">
+          <div className={colStyles.overallCol}>
+            <RatingBubble
+              className={styles.ratingCell}
+              rating={getOverallRatings(course, 'stat')}
+              colorMap={ratingColormap}
+            >
+              {getOverallRatings(course, 'display')}
+            </RatingBubble>
+          </div>
+          <div className={colStyles.workloadCol}>
+            <RatingBubble
+              className={clsx(styles.ratingCell, colStyles.workloadCol)}
+              rating={getWorkloadRatings(course, 'stat')}
+              colorMap={workloadColormap}
+            >
+              {getWorkloadRatings(course, 'display')}
+            </RatingBubble>
+          </div>
+          <div className={clsx('d-flex align-items-center', colStyles.profCol)}>
+            <div className={clsx('mr-2 h-100', styles.profRating)}>
               <RatingBubble
                 className={styles.ratingCell}
                 rating={getProfessorRatings(course, 'stat')}
@@ -288,11 +248,11 @@ function ResultsItem({
           </div>
         </div>
         {/* Previous Enrollment */}
-        <div style={enrollStyle} className="d-flex">
+        <div className={clsx('d-flex', colStyles.enrollCol)}>
           <span className="my-auto">{getEnrolled(course, 'display')}</span>
         </div>
         {/* Skills and Areas */}
-        <div style={saStyle} className="d-flex">
+        <div className={clsx('d-flex', colStyles.skillAreaCol)}>
           <span className={styles.skillsAreas}>
             {[...course.skills, ...course.areas].map((skill, index) => (
               <SkillBadge skill={skill} className="my-auto" key={index} />
@@ -300,15 +260,15 @@ function ResultsItem({
           </span>
         </div>
         {/* Course Meeting Days & Times */}
-        <div style={meetStyle}>
+        <div className={colStyles.meetCol}>
           <div className={styles.ellipsisText}>{course.times_summary}</div>
         </div>
         {/* Course Location */}
-        <div style={locStyle}>
+        <div className={colStyles.locCol}>
           <div className={styles.ellipsisText}>{course.locations_summary}</div>
         </div>
         {/* # Friends also shopping */}
-        <div style={friendsStyle} className="d-flex ">
+        <div className={clsx('d-flex', colStyles.friendsCol)}>
           <OverlayTrigger
             placement="top"
             overlay={(props) =>


### PR DESCRIPTION
Fully reactive to window resizing, works without JS, much faster and smoother transitions.