### PR TITLE
feat: course sorting should be stable and consistent

### DIFF
--- a/frontend/src/contexts/searchContext.tsx
+++ b/frontend/src/contexts/searchContext.tsx
@@ -67,7 +67,6 @@ export const skillsAreasOptions = ['Areas', 'Skills'].map((type) => ({
 
 const sortCriteria = {
   course_code: { label: 'Sort by Course Code', numeric: false },
-  number: { label: 'Sort by Course Number', numeric: true },
   title: { label: 'Sort by Course Title', numeric: false },
   friend: { label: 'Sort by Friends', numeric: true },
   average_rating: { label: 'Sort by Course Rating', numeric: true },
@@ -87,7 +86,11 @@ export const sortByOptions = Object.fromEntries(
 ) as { [k in SortKeys]: SortByOption };
 
 // We can only sort by primitive keys by default, unless we have special support
-export type SortKeys = keyof typeof sortCriteria;
+export type SortKeys =
+  | keyof typeof sortCriteria
+  | keyof {
+      [K in keyof Listing as Listing[K] extends string | number ? K : never]: K;
+    };
 
 export type SortByOption = Option & {
   value: SortKeys;


### PR DESCRIPTION
This PR avoids two courses from comparing equal in most cases. If the criterion doesn't return an order (for example, when sorting by rating), we default to sorting by season, course code, and section, which makes sure that no matter what intrinsic order these courses have in the first place, the returned order is always consistent.