### PR TITLE
feat: allow authed but no evals users to view worksheets

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,10 +50,6 @@ function AuthenticatedRoutes() {
   );
 
   const location = useLocation();
-  const messages = {
-    '/worksheet': 'your worksheet',
-    '/graphiql': 'the GraphQL interface',
-  };
 
   if (authStatus === 'loading') return <Spinner />;
 
@@ -61,18 +57,23 @@ function AuthenticatedRoutes() {
     case '/catalog':
       return <Outlet />;
 
+    case '/worksheet':
+      if (authStatus === 'authenticated') return <Outlet />;
+      return (
+        <NeedsLogin redirect={location.pathname} message="your worksheet" />
+      );
+
     case '/login':
       if (authStatus === 'authenticated')
         return <Navigate to="/catalog" replace />;
       return <Outlet />;
 
     case '/graphiql':
-    case '/worksheet':
       if (user.hasEvals) return <Outlet />;
       return (
         <NeedsLogin
           redirect={location.pathname}
-          message={messages[location.pathname]}
+          message="the GraphQL interface"
         />
       );
 


### PR DESCRIPTION
They can already interact with worksheets on the catalog, but they can't actually use the worksheet page.

Maybe we should hide the statistics panel? My personal preference is to use a placeholder like the catalog.