### PR TITLE
feat: display all eval questions in course modal

### DIFF
--- a/frontend/src/components/CourseModal/EvaluationRatings.tsx
+++ b/frontend/src/components/CourseModal/EvaluationRatings.tsx
@@ -18,7 +18,7 @@ function EvaluationRatings({
   if (!info) return null;
   const ratings = info.course.evaluation_ratings.map((x) => ({
     tag: x.evaluation_question.tag,
-    questionText: x.evaluation_question.question_text!,
+    questionText: x.evaluation_question.question_text,
     rating: x.rating as number[],
     options: x.evaluation_question.options as string[],
   }));

--- a/frontend/src/components/CourseModal/EvaluationRatings.tsx
+++ b/frontend/src/components/CourseModal/EvaluationRatings.tsx
@@ -1,10 +1,7 @@
 import RatingsGraph from './RatingsGraph';
 import type { SearchEvaluationNarrativesQuery } from '../../generated/graphql';
-import { evalQuestions } from '../../utilities/constants';
 import { TextComponent } from '../Typography';
 import styles from './EvaluationRatings.module.css';
-
-const questions = Object.keys(evalQuestions) as (keyof typeof evalQuestions)[];
 
 function EvaluationRatings({
   info,
@@ -15,48 +12,26 @@ function EvaluationRatings({
 }) {
   if (!info) return null;
   const ratings = info.course.evaluation_ratings.map((x) => ({
-    question: x.evaluation_question.question_text ?? '',
-    values: [...((x.rating as number[] | null) ?? [])],
+    tag: x.evaluation_question.tag,
+    questionText: x.evaluation_question.question_text!,
+    rating: x.rating as number[],
+    options: x.evaluation_question.options as string[],
   }));
 
-  // Dictionary with ratings for each question
-  const filteredRatings: { [code in keyof typeof evalQuestions]: number[] } = {
-    assessment: [],
-    workload: [],
-    engagement: [],
-    organized: [],
-    feedback: [],
-    challenge: [],
-  };
-  // Populate the lists above
-  ratings.forEach((rating) => {
-    questions.forEach((question) => {
-      // TODO: this logic is too hacky. We shouldn't be comparing a question
-      // text to an abstract code. Instead, let GraphQL return the code directly
-      // (Which is going to save some network bandwidth too!)
-      if (rating.question.includes(question))
-        filteredRatings[question] = rating.values;
-    });
-  });
-
-  const items = questions
-    .filter((question) => filteredRatings[question].length)
-    .map((question) => (
-      <div key={question}>
+  const items = ratings
+    .filter((question) => question.rating.length)
+    .map(({ tag, questionText, rating, options }) => (
+      <div key={tag ?? questionText}>
         <div className={styles.question}>
-          <div className={styles.questionTitle}>
-            {evalQuestions[question].title}
-          </div>
+          {tag && <div className={styles.questionTitle}>{tag}</div>}
           <div className={styles.questionText}>
-            <TextComponent type="secondary">
-              {evalQuestions[question].question}
-            </TextComponent>
+            <TextComponent type="secondary">{questionText}</TextComponent>
           </div>
         </div>
         <RatingsGraph
-          ratings={filteredRatings[question]}
-          reverse={question === 'workload' || question === 'challenge'}
-          labels={evalQuestions[question].labels}
+          ratings={rating}
+          reverse={tag === 'Workload' || tag === 'Intellectual Challenge'}
+          labels={options}
           enrolled={info.enrolled ?? 0}
         />
       </div>

--- a/frontend/src/components/CourseModal/EvaluationRatings.tsx
+++ b/frontend/src/components/CourseModal/EvaluationRatings.tsx
@@ -1,7 +1,12 @@
 import RatingsGraph from './RatingsGraph';
 import type { SearchEvaluationNarrativesQuery } from '../../generated/graphql';
+import { evalQuestionTags } from '../../utilities/constants';
 import { TextComponent } from '../Typography';
 import styles from './EvaluationRatings.module.css';
+
+const tagIndex = Object.fromEntries(
+  evalQuestionTags.map((tag, index) => [tag, index]),
+);
 
 function EvaluationRatings({
   info,
@@ -17,6 +22,12 @@ function EvaluationRatings({
     rating: x.rating as number[],
     options: x.evaluation_question.options as string[],
   }));
+  ratings.sort((a, b) => {
+    if (a.tag && b.tag) return tagIndex[a.tag]! - tagIndex[b.tag]!;
+    if (a.tag) return -1;
+    if (b.tag) return 1;
+    return a.questionText.localeCompare(b.questionText);
+  });
 
   const items = ratings
     .filter((question) => question.rating.length)

--- a/frontend/src/components/CourseModal/EvaluationResponses.tsx
+++ b/frontend/src/components/CourseModal/EvaluationResponses.tsx
@@ -58,17 +58,17 @@ function EvaluationResponses({
         data.evaluation_question.tag ??
         truncatedText(data.evaluation_question.question_text, 15, '');
       const questionInfo = tempResponses[questionTag] ?? {
-        questionText: data.evaluation_question.question_text!,
+        questionText: data.evaluation_question.question_text,
         responses: [],
       };
       if (!questionInfo.questionText) {
-        questionInfo.questionText = data.evaluation_question.question_text!;
+        questionInfo.questionText = data.evaluation_question.question_text;
       } else if (
         data.evaluation_question.question_text !== questionInfo.questionText
       ) {
         Sentry.captureException(
           new Error(
-            `Question text mismatch: ${questionTag} ${data.evaluation_question.question_text!} vs. ${questionInfo.questionText}`,
+            `Question text mismatch: ${questionTag} ${data.evaluation_question.question_text} vs. ${questionInfo.questionText}`,
           ),
         );
       }

--- a/frontend/src/components/CourseModal/EvaluationResponses.tsx
+++ b/frontend/src/components/CourseModal/EvaluationResponses.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { Tab, Tabs } from 'react-bootstrap';
 import Mark from 'mark.js';
 import type { SearchEvaluationNarrativesQuery } from '../../generated/graphql';
+import { evalQuestionTags } from '../../utilities/constants';
 import { Input, TextComponent } from '../Typography';
 import styles from './EvaluationResponses.module.css';
 
@@ -48,7 +49,9 @@ function EvaluationResponses({
     if (!info) return [{}, {}];
     const tempResponses: {
       [tag: string]: { questionText: string; responses: string[] };
-    } = {};
+    } = Object.fromEntries(
+      evalQuestionTags.map((tag) => [tag, { questionText: '', responses: [] }]),
+    );
     info.course.evaluation_narratives.forEach((data) => {
       const questionTag =
         data.evaluation_question.tag ?? data.evaluation_question.question_text!;
@@ -56,7 +59,9 @@ function EvaluationResponses({
         questionText: data.evaluation_question.question_text!,
         responses: [],
       };
-      if (
+      if (!questionInfo.questionText) {
+        questionInfo.questionText = data.evaluation_question.question_text!;
+      } else if (
         data.evaluation_question.question_text !== questionInfo.questionText
       ) {
         Sentry.captureException(

--- a/frontend/src/components/CourseModal/EvaluationResponses.tsx
+++ b/frontend/src/components/CourseModal/EvaluationResponses.tsx
@@ -1,10 +1,37 @@
 import React, { useState, useMemo } from 'react';
+import * as Sentry from '@sentry/react';
 import clsx from 'clsx';
 import { Tab, Tabs } from 'react-bootstrap';
 import Mark from 'mark.js';
 import type { SearchEvaluationNarrativesQuery } from '../../generated/graphql';
 import { Input, TextComponent } from '../Typography';
 import styles from './EvaluationResponses.module.css';
+
+function CommentRows({
+  responses,
+  filter,
+}: {
+  readonly responses: string[];
+  readonly filter: string;
+}) {
+  if (responses.length === 0) return [];
+  const filteredResps = responses
+    .filter((response) => response.toLowerCase().includes(filter.toLowerCase()))
+    .map((response, index) => (
+      // .responses is used for highlighting
+      <div key={index} className={clsx(styles.commentRow, 'responses')}>
+        <TextComponent type="secondary">{response}</TextComponent>
+      </div>
+    ));
+  if (filteredResps.length === 0) {
+    return [
+      <div key={0} className={styles.commentRow}>
+        <TextComponent type="secondary">No matches found.</TextComponent>
+      </div>,
+    ];
+  }
+  return filteredResps;
+}
 
 function EvaluationResponses({
   info,
@@ -17,69 +44,45 @@ function EvaluationResponses({
   const [sortOrder, setSortOrder] = useState('length');
 
   // Dictionary that holds the comments for each question
-  const [responses, sortedResponses] = useMemo(() => {
+  const [origResponses, sortedResponses] = useMemo(() => {
     if (!info) return [{}, {}];
-    const tempResponses: { [questionText: string]: string[] } = {};
-    // Add comments to responses dictionary
-    info.course.evaluation_narratives_aggregate.nodes.forEach((node) => {
-      if (node.evaluation_question.question_text && node.comment) {
-        (tempResponses[node.evaluation_question.question_text] ??= []).push(
-          node.comment,
+    const tempResponses: {
+      [tag: string]: { questionText: string; responses: string[] };
+    } = {};
+    info.course.evaluation_narratives.forEach((data) => {
+      const questionTag =
+        data.evaluation_question.tag ?? data.evaluation_question.question_text!;
+      const questionInfo = tempResponses[questionTag] ?? {
+        questionText: data.evaluation_question.question_text!,
+        responses: [],
+      };
+      if (
+        data.evaluation_question.question_text !== questionInfo.questionText
+      ) {
+        Sentry.captureException(
+          new Error(
+            `Question text mismatch: ${questionTag} ${data.evaluation_question.question_text!} vs. ${questionInfo.questionText}`,
+          ),
         );
       }
+      if (data.comment) questionInfo.responses.push(data.comment);
+      tempResponses[questionTag] = questionInfo;
     });
     const sortedResponses = JSON.parse(
       JSON.stringify(tempResponses),
     ) as typeof tempResponses;
     for (const r of Object.values(tempResponses))
-      r.sort((a, b) => b.length - a.length);
+      r.responses.sort((a, b) => b.length - a.length);
 
     return [tempResponses, sortedResponses];
   }, [info]);
 
   // Number of questions
-  const numQuestions = Object.keys(responses).length;
+  const numQuestions = Object.keys(origResponses).length;
 
   const [filter, setFilter] = useState('');
 
-  // Generate HTML to hold the responses to each question
-  const [recommend, skills, strengths, summary] = useMemo(() => {
-    let tempRecommend: JSX.Element[] = [];
-    let tempSkills: JSX.Element[] = [];
-    let tempStrengths: JSX.Element[] = [];
-    let tempSummary: JSX.Element[] = [];
-    const curResponses = sortOrder === 'length' ? sortedResponses : responses;
-    const genTemp = (resps: string[]) => {
-      if (resps.length === 0) return [];
-      const filteredResps = resps
-        .filter((response) =>
-          response.toLowerCase().includes(filter.toLowerCase()),
-        )
-        .map((response, index) => (
-          // .responses is used for highlighting
-          <div key={index} className={clsx(styles.commentRow, 'responses')}>
-            <TextComponent type="secondary">{response}</TextComponent>
-          </div>
-        ));
-      if (filteredResps.length === 0) {
-        return [
-          <div key={0} className={styles.commentRow}>
-            <TextComponent type="secondary">No matches found.</TextComponent>
-          </div>,
-        ];
-      }
-      return filteredResps;
-    };
-    for (const [question, qResponses] of Object.entries(curResponses)) {
-      if (question.includes('summarize')) tempSummary = genTemp(qResponses);
-      else if (question.includes('recommend'))
-        tempRecommend = genTemp(qResponses);
-      else if (question.includes('skills')) tempSkills = genTemp(qResponses);
-      else if (question.includes('strengths'))
-        tempStrengths = genTemp(qResponses);
-    }
-    return [tempRecommend, tempSkills, tempStrengths, tempSummary];
-  }, [responses, sortOrder, sortedResponses, filter]);
+  const curResponses = sortOrder === 'length' ? sortedResponses : origResponses;
 
   const context = document.querySelectorAll('.responses');
   const instance = new Mark(context);
@@ -146,41 +149,12 @@ function EvaluationResponses({
             ?.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
         }}
       >
-        {[
-          {
-            key: 'recommended',
-            title: 'Recommend?',
-            question:
-              'Would you recommend this course to another student? Please explain.',
-            responses: recommend,
-          },
-          {
-            key: 'knowledge/skills',
-            title: 'Skills',
-            question:
-              'What knowledge, skills, and insights did you develop by taking this course?',
-            responses: skills,
-          },
-          {
-            key: 'strengths/weaknesses',
-            title: 'Strengths/Weaknesses',
-            question:
-              'What are the strengths and weaknesses of this course and how could it be improved?',
-            responses: strengths,
-          },
-          {
-            key: 'summary',
-            title: 'Summary',
-            question:
-              'How would you summarize this course? Would you recommend it to another student? Why or why not?',
-            responses: summary,
-          },
-        ].map(
-          ({ key, title, question, responses }) =>
+        {Object.entries(curResponses).map(
+          ([tag, { questionText, responses }]) =>
             responses.length !== 0 && (
-              <Tab eventKey={key} title={title} key={key}>
+              <Tab eventKey={tag} title={tag} key={tag}>
                 <div className={styles.questionHeader}>
-                  <TextComponent>{question}</TextComponent>
+                  <TextComponent>{questionText}</TextComponent>
                 </div>
                 <p className={styles.responseStats}>
                   <TextComponent type="secondary">
@@ -189,7 +163,7 @@ function EvaluationResponses({
                     responses
                   </TextComponent>
                 </p>
-                {responses}
+                <CommentRows responses={responses} filter={filter} />
               </Tab>
             ),
         )}

--- a/frontend/src/components/CourseModal/EvaluationResponses.tsx
+++ b/frontend/src/components/CourseModal/EvaluationResponses.tsx
@@ -5,6 +5,7 @@ import { Tab, Tabs } from 'react-bootstrap';
 import Mark from 'mark.js';
 import type { SearchEvaluationNarrativesQuery } from '../../generated/graphql';
 import { evalQuestionTags } from '../../utilities/constants';
+import { truncatedText } from '../../utilities/course';
 import { Input, TextComponent } from '../Typography';
 import styles from './EvaluationResponses.module.css';
 
@@ -54,7 +55,8 @@ function EvaluationResponses({
     );
     info.course.evaluation_narratives.forEach((data) => {
       const questionTag =
-        data.evaluation_question.tag ?? data.evaluation_question.question_text!;
+        data.evaluation_question.tag ??
+        truncatedText(data.evaluation_question.question_text, 15, '');
       const questionInfo = tempResponses[questionTag] ?? {
         questionText: data.evaluation_question.question_text!,
         responses: [],

--- a/frontend/src/components/CourseModal/RatingsGraph.tsx
+++ b/frontend/src/components/CourseModal/RatingsGraph.tsx
@@ -25,8 +25,6 @@ function RatingsGraph({
   const columns = ratings.map((rating, indx) => {
     // Calculate height of the bar
     const height = rating ? MIN_HEIGHT + (rating / maxVal) * 100 : 0;
-    // Skip to last color if this is the yes/no question
-    if (indx === 1 && ratings.length === 2) indx = 4;
     // Build bar
     return (
       <div key={labels[indx]} className={styles.bar}>
@@ -41,17 +39,10 @@ function RatingsGraph({
             height: `${height.toString()}px`,
           }}
         />
-        {ratings.length === 2 && (
-          <p className={clsx(styles.label, styles.value, 'm-0')}>
-            {indx === 0 ? 'yes' : 'no'}
-          </p>
-        )}
-        {ratings.length === 5 && (
-          <p className={clsx(styles.label, styles.value, 'm-0')}>
-            <span className="d-none d-sm-block">{labels[indx]}</span>
-            <span className="d-sm-none">{indx + 1}</span>
-          </p>
-        )}
+        <p className={clsx(styles.label, styles.value, 'm-0')}>
+          <span className="d-none d-sm-block">{labels[indx]}</span>
+          <span className="d-sm-none">{indx + 1}</span>
+        </p>
       </div>
     );
   });

--- a/frontend/src/contexts/searchContext.tsx
+++ b/frontend/src/contexts/searchContext.tsx
@@ -612,7 +612,7 @@ export function SearchProvider({
               .toLowerCase()
               .startsWith(numberFirstChar.toLowerCase() + token)) ||
           (searchDescription.value &&
-            listing.description?.toLowerCase().includes(token)) ||
+            listing.description.toLowerCase().includes(token)) ||
           listing.title.toLowerCase().includes(token) ||
           listing.professor_names.some((professor) =>
             professor.toLowerCase().includes(token),

--- a/frontend/src/generated/graphql.schema.json
+++ b/frontend/src/generated/graphql.schema.json
@@ -2291,13 +2291,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -19865,9 +19861,13 @@
               }
             ],
             "type": {
-              "kind": "SCALAR",
-              "name": "json",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "json",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -21870,9 +21870,13 @@
               }
             ],
             "type": {
-              "kind": "SCALAR",
-              "name": "json",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "json",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -21903,7 +21907,7 @@
           },
           {
             "name": "times_by_day",
-            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location)`",
+            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location, locatio_url)`",
             "args": [
               {
                 "name": "path",
@@ -21919,9 +21923,13 @@
               }
             ],
             "type": {
-              "kind": "SCALAR",
-              "name": "json",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "json",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -21943,9 +21951,13 @@
             "description": "Complete course title",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -25240,7 +25252,7 @@
           },
           {
             "name": "times_by_day",
-            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location)`",
+            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location, locatio_url)`",
             "type": {
               "kind": "SCALAR",
               "name": "json",
@@ -28523,7 +28535,7 @@
           },
           {
             "name": "times_by_day",
-            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location)`",
+            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location, locatio_url)`",
             "type": {
               "kind": "SCALAR",
               "name": "json",
@@ -30151,7 +30163,7 @@
           },
           {
             "name": "times_by_day",
-            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location)`",
+            "description": "Course meeting times by day, with days as keys and\n        tuples of `(start_time, end_time, location, locatio_url)`",
             "type": {
               "kind": "SCALAR",
               "name": "json",
@@ -32029,9 +32041,13 @@
             "description": "Response to the question",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -32041,9 +32057,13 @@
             "description": "VADER sentiment 'compound' score (valence aggregate of neg, neu, pos)",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "float8",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -32053,9 +32073,13 @@
             "description": "VADER sentiment 'neg' score (negativity)",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "float8",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -32065,9 +32089,13 @@
             "description": "VADER sentiment 'neu' score (neutrality)",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "float8",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -32077,9 +32105,13 @@
             "description": "VADER sentiment 'pos' score (positivity)",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "float8",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -36941,9 +36973,13 @@
             "description": "True if the question has narrative responses.\n        False if the question has categorica/numerical responses",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -36994,9 +37030,13 @@
             "description": "The question text",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -38207,9 +38247,13 @@
               }
             ],
             "type": {
-              "kind": "SCALAR",
-              "name": "json",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "json",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -44806,9 +44850,13 @@
             "description": "[computed] subject + number (e.g. \"AMST 312\")",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -56706,9 +56754,13 @@
             "description": "[computed] Season of the semester - one of spring, summer, or fall",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -56718,9 +56770,13 @@
             "description": "[computed] Year of the semester",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/frontend/src/generated/graphql.schema.json
+++ b/frontend/src/generated/graphql.schema.json
@@ -1586,9 +1586,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1610,9 +1614,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1634,9 +1642,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1658,9 +1670,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1782,27 +1798,19 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "enrolled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "args": [],
             "type": {
@@ -2122,9 +2130,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2279,9 +2291,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4033,18 +4049,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "args": [],
@@ -4322,18 +4326,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -4757,18 +4749,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5725,18 +5705,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "type": {
@@ -6097,18 +6065,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6742,18 +6698,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extra_info",
             "description": null,
             "args": [],
@@ -7247,18 +7191,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -7772,18 +7704,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extra_info",
             "description": null,
             "args": [],
@@ -8277,18 +8197,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8965,18 +8873,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extra_info",
             "description": null,
             "type": {
@@ -9602,12 +9498,6 @@
           },
           {
             "name": "enrolled",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -10560,18 +10450,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extra_info",
             "description": null,
             "type": {
@@ -11146,18 +11024,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "args": [],
@@ -11446,18 +11312,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "type": {
@@ -11733,18 +11587,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "args": [],
             "type": {
@@ -12044,18 +11886,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "type": {
@@ -12331,18 +12161,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "args": [],
             "type": {
@@ -12631,18 +12449,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -13041,18 +12847,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -13638,18 +13432,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "args": [],
@@ -13938,18 +13720,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "type": {
@@ -14180,12 +13950,6 @@
           },
           {
             "name": "enrolled",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -14682,18 +14446,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "args": [],
@@ -14982,18 +14734,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "type": {
@@ -15269,18 +15009,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "args": [],
             "type": {
@@ -15580,18 +15308,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "last_enrollment",
             "description": null,
             "type": {
@@ -15867,18 +15583,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "args": [],
             "type": {
@@ -16167,18 +15871,6 @@
           },
           {
             "name": "enrolled",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -37258,7 +36950,7 @@
           },
           {
             "name": "options",
-            "description": "JSON array of possible responses (only if the question is not a narrative",
+            "description": "JSON array of possible responses (only if the question is not a narrative)",
             "args": [
               {
                 "name": "path",
@@ -37311,7 +37003,7 @@
           },
           {
             "name": "tag",
-            "description": "[computed] Question type (used for computing ratings, since one\n        question may be coded differently for different respondants)",
+            "description": "[computed] Question type. The 'Overall' and 'Workload' tags\n        are used to compute average ratings, while others are purely for\n        identification purposes. No other commonality, other than that they\n        contain similar keywords, is guaranteed—for example, they may have\n        different options, or even differ in being narrative or not.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37690,7 +37382,7 @@
           },
           {
             "name": "options",
-            "description": "JSON array of possible responses (only if the question is not a narrative",
+            "description": "JSON array of possible responses (only if the question is not a narrative)",
             "type": {
               "kind": "SCALAR",
               "name": "json",
@@ -37726,7 +37418,7 @@
           },
           {
             "name": "tag",
-            "description": "[computed] Question type (used for computing ratings, since one\n        question may be coded differently for different respondants)",
+            "description": "[computed] Question type. The 'Overall' and 'Workload' tags\n        are used to compute average ratings, while others are purely for\n        identification purposes. No other commonality, other than that they\n        contain similar keywords, is guaranteed—for example, they may have\n        different options, or even differ in being narrative or not.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -37772,7 +37464,7 @@
           },
           {
             "name": "tag",
-            "description": "[computed] Question type (used for computing ratings, since one\n        question may be coded differently for different respondants)",
+            "description": "[computed] Question type. The 'Overall' and 'Workload' tags\n        are used to compute average ratings, while others are purely for\n        identification purposes. No other commonality, other than that they\n        contain similar keywords, is guaranteed—for example, they may have\n        different options, or even differ in being narrative or not.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37819,7 +37511,7 @@
           },
           {
             "name": "tag",
-            "description": "[computed] Question type (used for computing ratings, since one\n        question may be coded differently for different respondants)",
+            "description": "[computed] Question type. The 'Overall' and 'Workload' tags\n        are used to compute average ratings, while others are purely for\n        identification purposes. No other commonality, other than that they\n        contain similar keywords, is guaranteed—for example, they may have\n        different options, or even differ in being narrative or not.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -38171,7 +37863,7 @@
           },
           {
             "name": "options",
-            "description": "JSON array of possible responses (only if the question is not a narrative",
+            "description": "JSON array of possible responses (only if the question is not a narrative)",
             "type": {
               "kind": "SCALAR",
               "name": "json",
@@ -38207,7 +37899,7 @@
           },
           {
             "name": "tag",
-            "description": "[computed] Question type (used for computing ratings, since one\n        question may be coded differently for different respondants)",
+            "description": "[computed] Question type. The 'Overall' and 'Workload' tags\n        are used to compute average ratings, while others are purely for\n        identification purposes. No other commonality, other than that they\n        contain similar keywords, is guaranteed—for example, they may have\n        different options, or even differ in being narrative or not.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -38281,7 +37973,7 @@
           },
           {
             "name": "options",
-            "description": "JSON array of possible responses (only if the question is not a narrative",
+            "description": "JSON array of possible responses (only if the question is not a narrative)",
             "type": {
               "kind": "SCALAR",
               "name": "json",
@@ -38317,7 +38009,7 @@
           },
           {
             "name": "tag",
-            "description": "[computed] Question type (used for computing ratings, since one\n        question may be coded differently for different respondants)",
+            "description": "[computed] Question type. The 'Overall' and 'Workload' tags\n        are used to compute average ratings, while others are purely for\n        identification purposes. No other commonality, other than that they\n        contain similar keywords, is guaranteed—for example, they may have\n        different options, or even differ in being narrative or not.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -40645,18 +40337,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extras",
             "description": "Arbitrary additional information attached to an evaluation",
             "args": [
@@ -41004,18 +40684,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -41176,18 +40844,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extras",
             "description": null,
             "type": {
@@ -41312,18 +40968,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "type": {
@@ -41421,18 +41065,6 @@
           {
             "name": "enrolled",
             "description": "Number of students enrolled in course",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -41549,18 +41181,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -41646,18 +41266,6 @@
           {
             "name": "enrolled",
             "description": "Number of students enrolled in course",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -41929,18 +41537,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extras",
             "description": null,
             "type": {
@@ -42047,12 +41643,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extras",
             "description": "column name",
             "isDeprecated": false,
@@ -42130,18 +41720,6 @@
           {
             "name": "enrolled",
             "description": "Number of students enrolled in course",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -42258,18 +41836,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -42365,18 +41931,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -42462,18 +42016,6 @@
           {
             "name": "enrolled",
             "description": "Number of students enrolled in course",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -42619,18 +42161,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extras",
             "description": "Arbitrary additional information attached to an evaluation",
             "type": {
@@ -42737,18 +42267,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -42812,12 +42330,6 @@
           },
           {
             "name": "enrolled",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -42960,18 +42472,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -43067,18 +42567,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "no_response",
             "description": "Number of students who did not respond",
             "args": [],
@@ -43164,18 +42652,6 @@
           {
             "name": "enrolled",
             "description": "Number of students enrolled in course",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enrollment",
-            "description": "Placeholder for compatibility (previously held JSON for enrollment)",
             "args": [],
             "type": {
               "kind": "SCALAR",

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -243,7 +243,6 @@ export type Computed_Listing_Info_Avg_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -281,7 +280,6 @@ export type Computed_Listing_Info_Bool_Exp = {
   declined: InputMaybe<Int_Comparison_Exp>;
   description: InputMaybe<String_Comparison_Exp>;
   enrolled: InputMaybe<Int_Comparison_Exp>;
-  enrollment: InputMaybe<Int_Comparison_Exp>;
   extra_info: InputMaybe<String_Comparison_Exp>;
   final_exam: InputMaybe<String_Comparison_Exp>;
   flag_info: InputMaybe<Jsonb_Comparison_Exp>;
@@ -373,7 +371,6 @@ export type Computed_Listing_Info_Inc_Input = {
   crn: InputMaybe<Scalars['Int']['input']>;
   declined: InputMaybe<Scalars['Int']['input']>;
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   last_enrollment: InputMaybe<Scalars['Int']['input']>;
   last_enrollment_course_id: InputMaybe<Scalars['Int']['input']>;
   last_offered_course_id: InputMaybe<Scalars['Int']['input']>;
@@ -408,7 +405,6 @@ export type Computed_Listing_Info_Insert_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   description: InputMaybe<Scalars['String']['input']>;
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   extra_info: InputMaybe<Scalars['String']['input']>;
   final_exam: InputMaybe<Scalars['String']['input']>;
   flag_info: InputMaybe<Scalars['jsonb']['input']>;
@@ -464,7 +460,6 @@ export type Computed_Listing_Info_Max_Order_By = {
   declined: InputMaybe<Order_By>;
   description: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   extra_info: InputMaybe<Order_By>;
   final_exam: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
@@ -510,7 +505,6 @@ export type Computed_Listing_Info_Min_Order_By = {
   declined: InputMaybe<Order_By>;
   description: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   extra_info: InputMaybe<Order_By>;
   final_exam: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
@@ -567,7 +561,6 @@ export type Computed_Listing_Info_Order_By = {
   declined: InputMaybe<Order_By>;
   description: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   extra_info: InputMaybe<Order_By>;
   final_exam: InputMaybe<Order_By>;
   flag_info: InputMaybe<Order_By>;
@@ -658,8 +651,6 @@ export enum Computed_Listing_Info_Select_Column {
   Description = 'description',
   /** column name */
   Enrolled = 'enrolled',
-  /** column name */
-  Enrollment = 'enrollment',
   /** column name */
   ExtraInfo = 'extra_info',
   /** column name */
@@ -917,7 +908,6 @@ export type Computed_Listing_Info_Set_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   description: InputMaybe<Scalars['String']['input']>;
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   extra_info: InputMaybe<Scalars['String']['input']>;
   final_exam: InputMaybe<Scalars['String']['input']>;
   flag_info: InputMaybe<Scalars['jsonb']['input']>;
@@ -969,7 +959,6 @@ export type Computed_Listing_Info_Stddev_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -997,7 +986,6 @@ export type Computed_Listing_Info_Stddev_Pop_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -1025,7 +1013,6 @@ export type Computed_Listing_Info_Stddev_Samp_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -1067,7 +1054,6 @@ export type Computed_Listing_Info_Stream_Cursor_Value_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   description: InputMaybe<Scalars['String']['input']>;
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   extra_info: InputMaybe<Scalars['String']['input']>;
   final_exam: InputMaybe<Scalars['String']['input']>;
   flag_info: InputMaybe<Scalars['jsonb']['input']>;
@@ -1119,7 +1105,6 @@ export type Computed_Listing_Info_Sum_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -1174,8 +1159,6 @@ export enum Computed_Listing_Info_Update_Column {
   Description = 'description',
   /** column name */
   Enrolled = 'enrolled',
-  /** column name */
-  Enrollment = 'enrollment',
   /** column name */
   ExtraInfo = 'extra_info',
   /** column name */
@@ -1278,7 +1261,6 @@ export type Computed_Listing_Info_Var_Pop_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -1306,7 +1288,6 @@ export type Computed_Listing_Info_Var_Samp_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -1334,7 +1315,6 @@ export type Computed_Listing_Info_Variance_Order_By = {
   crn: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   last_enrollment: InputMaybe<Order_By>;
   last_enrollment_course_id: InputMaybe<Order_By>;
   last_offered_course_id: InputMaybe<Order_By>;
@@ -4033,15 +4013,18 @@ export type Evaluation_Questions_Insert_Input = {
    *         False if the question has categorica/numerical responses
    */
   is_narrative: InputMaybe<Scalars['Boolean']['input']>;
-  /** JSON array of possible responses (only if the question is not a narrative */
+  /** JSON array of possible responses (only if the question is not a narrative) */
   options: InputMaybe<Scalars['json']['input']>;
   /** Question code from OCE (e.g. "YC402") */
   question_code: InputMaybe<Scalars['String']['input']>;
   /** The question text */
   question_text: InputMaybe<Scalars['String']['input']>;
   /**
-   * [computed] Question type (used for computing ratings, since one
-   *         question may be coded differently for different respondants)
+   * [computed] Question type. The 'Overall' and 'Workload' tags
+   *         are used to compute average ratings, while others are purely for
+   *         identification purposes. No other commonality, other than that they
+   *         contain similar keywords, is guaranteed—for example, they may have
+   *         different options, or even differ in being narrative or not.
    */
   tag: InputMaybe<Scalars['String']['input']>;
 };
@@ -4098,15 +4081,18 @@ export type Evaluation_Questions_Set_Input = {
    *         False if the question has categorica/numerical responses
    */
   is_narrative: InputMaybe<Scalars['Boolean']['input']>;
-  /** JSON array of possible responses (only if the question is not a narrative */
+  /** JSON array of possible responses (only if the question is not a narrative) */
   options: InputMaybe<Scalars['json']['input']>;
   /** Question code from OCE (e.g. "YC402") */
   question_code: InputMaybe<Scalars['String']['input']>;
   /** The question text */
   question_text: InputMaybe<Scalars['String']['input']>;
   /**
-   * [computed] Question type (used for computing ratings, since one
-   *         question may be coded differently for different respondants)
+   * [computed] Question type. The 'Overall' and 'Workload' tags
+   *         are used to compute average ratings, while others are purely for
+   *         identification purposes. No other commonality, other than that they
+   *         contain similar keywords, is guaranteed—for example, they may have
+   *         different options, or even differ in being narrative or not.
    */
   tag: InputMaybe<Scalars['String']['input']>;
 };
@@ -4126,15 +4112,18 @@ export type Evaluation_Questions_Stream_Cursor_Value_Input = {
    *         False if the question has categorica/numerical responses
    */
   is_narrative: InputMaybe<Scalars['Boolean']['input']>;
-  /** JSON array of possible responses (only if the question is not a narrative */
+  /** JSON array of possible responses (only if the question is not a narrative) */
   options: InputMaybe<Scalars['json']['input']>;
   /** Question code from OCE (e.g. "YC402") */
   question_code: InputMaybe<Scalars['String']['input']>;
   /** The question text */
   question_text: InputMaybe<Scalars['String']['input']>;
   /**
-   * [computed] Question type (used for computing ratings, since one
-   *         question may be coded differently for different respondants)
+   * [computed] Question type. The 'Overall' and 'Workload' tags
+   *         are used to compute average ratings, while others are purely for
+   *         identification purposes. No other commonality, other than that they
+   *         contain similar keywords, is guaranteed—for example, they may have
+   *         different options, or even differ in being narrative or not.
    */
   tag: InputMaybe<Scalars['String']['input']>;
 };
@@ -4402,7 +4391,6 @@ export type Evaluation_Statistics_Bool_Exp = {
   course_id: InputMaybe<Int_Comparison_Exp>;
   declined: InputMaybe<Int_Comparison_Exp>;
   enrolled: InputMaybe<Int_Comparison_Exp>;
-  enrollment: InputMaybe<Int_Comparison_Exp>;
   extras: InputMaybe<Json_Comparison_Exp>;
   no_response: InputMaybe<Int_Comparison_Exp>;
   responses: InputMaybe<Int_Comparison_Exp>;
@@ -4426,8 +4414,6 @@ export type Evaluation_Statistics_Inc_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   /** Number of students enrolled in course */
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  /** Placeholder for compatibility (previously held JSON for enrollment) */
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   /** Number of students who did not respond */
   no_response: InputMaybe<Scalars['Int']['input']>;
   /** Number of responses */
@@ -4447,8 +4433,6 @@ export type Evaluation_Statistics_Insert_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   /** Number of students enrolled in course */
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  /** Placeholder for compatibility (previously held JSON for enrollment) */
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   /** Arbitrary additional information attached to an evaluation */
   extras: InputMaybe<Scalars['json']['input']>;
   /** Number of students who did not respond */
@@ -4479,7 +4463,6 @@ export type Evaluation_Statistics_Order_By = {
   course_id: InputMaybe<Order_By>;
   declined: InputMaybe<Order_By>;
   enrolled: InputMaybe<Order_By>;
-  enrollment: InputMaybe<Order_By>;
   extras: InputMaybe<Order_By>;
   no_response: InputMaybe<Order_By>;
   responses: InputMaybe<Order_By>;
@@ -4504,8 +4487,6 @@ export enum Evaluation_Statistics_Select_Column {
   /** column name */
   Enrolled = 'enrolled',
   /** column name */
-  Enrollment = 'enrollment',
-  /** column name */
   Extras = 'extras',
   /** column name */
   NoResponse = 'no_response',
@@ -4525,8 +4506,6 @@ export type Evaluation_Statistics_Set_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   /** Number of students enrolled in course */
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  /** Placeholder for compatibility (previously held JSON for enrollment) */
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   /** Arbitrary additional information attached to an evaluation */
   extras: InputMaybe<Scalars['json']['input']>;
   /** Number of students who did not respond */
@@ -4555,8 +4534,6 @@ export type Evaluation_Statistics_Stream_Cursor_Value_Input = {
   declined: InputMaybe<Scalars['Int']['input']>;
   /** Number of students enrolled in course */
   enrolled: InputMaybe<Scalars['Int']['input']>;
-  /** Placeholder for compatibility (previously held JSON for enrollment) */
-  enrollment: InputMaybe<Scalars['Int']['input']>;
   /** Arbitrary additional information attached to an evaluation */
   extras: InputMaybe<Scalars['json']['input']>;
   /** Number of students who did not respond */
@@ -4577,8 +4554,6 @@ export enum Evaluation_Statistics_Update_Column {
   Declined = 'declined',
   /** column name */
   Enrolled = 'enrolled',
-  /** column name */
-  Enrollment = 'enrollment',
   /** column name */
   Extras = 'extras',
   /** column name */
@@ -5463,23 +5438,23 @@ export type SearchEvaluationNarrativesQuery = {
     enrolled: number | null;
     course: {
       __typename?: 'courses';
-      evaluation_narratives_aggregate: {
-        __typename?: 'evaluation_narratives_aggregate';
-        nodes: Array<{
-          __typename?: 'evaluation_narratives';
-          comment: string | null;
-          evaluation_question: {
-            __typename?: 'evaluation_questions';
-            question_text: string | null;
-          };
-        }>;
-      };
+      evaluation_narratives: Array<{
+        __typename?: 'evaluation_narratives';
+        comment: string | null;
+        evaluation_question: {
+          __typename?: 'evaluation_questions';
+          question_text: string | null;
+          tag: string | null;
+        };
+      }>;
       evaluation_ratings: Array<{
         __typename?: 'evaluation_ratings';
         rating: any | null;
         evaluation_question: {
           __typename?: 'evaluation_questions';
           question_text: string | null;
+          options: any | null;
+          tag: string | null;
         };
       }>;
     };
@@ -5530,7 +5505,7 @@ export type ListingFragment = {
   course_code: string;
   credits: number | null;
   crn: number;
-  description: string | null;
+  description: string;
   extra_info: string;
   final_exam: string | null;
   flag_info: any;
@@ -5541,7 +5516,7 @@ export type ListingFragment = {
   professor_ids: any;
   professor_names: any;
   regnotes: string | null;
-  requirements: string | null;
+  requirements: string;
   rp_attr: string | null;
   same_course_id: number;
   same_course_and_profs_id: number;
@@ -5551,7 +5526,7 @@ export type ListingFragment = {
   section: string;
   skills: any;
   subject: string;
-  syllabus_url: string | null;
+  syllabus_url: string;
   times_by_day: any;
   times_summary: string;
   title: string;
@@ -5713,18 +5688,19 @@ export const SearchEvaluationNarrativesDocument = gql`
     ) {
       crn
       course {
-        evaluation_narratives_aggregate {
-          nodes {
-            comment
-            evaluation_question {
-              question_text
-            }
+        evaluation_narratives {
+          comment
+          evaluation_question {
+            question_text
+            tag
           }
         }
         evaluation_ratings {
           rating
           evaluation_question {
             question_text
+            options
+            tag
           }
         }
       }

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -2153,7 +2153,7 @@ export type Courses_Insert_Input = {
   sysem: InputMaybe<Scalars['Boolean']['input']>;
   /**
    * Course meeting times by day, with days as keys and
-   *         tuples of `(start_time, end_time, location)`
+   *         tuples of `(start_time, end_time, location, locatio_url)`
    */
   times_by_day: InputMaybe<Scalars['json']['input']>;
   /** Course times, displayed in the "Times" column in CourseTable */
@@ -2760,7 +2760,7 @@ export type Courses_Set_Input = {
   sysem: InputMaybe<Scalars['Boolean']['input']>;
   /**
    * Course meeting times by day, with days as keys and
-   *         tuples of `(start_time, end_time, location)`
+   *         tuples of `(start_time, end_time, location, locatio_url)`
    */
   times_by_day: InputMaybe<Scalars['json']['input']>;
   /** Course times, displayed in the "Times" column in CourseTable */
@@ -3083,7 +3083,7 @@ export type Courses_Stream_Cursor_Value_Input = {
   sysem: InputMaybe<Scalars['Boolean']['input']>;
   /**
    * Course meeting times by day, with days as keys and
-   *         tuples of `(start_time, end_time, location)`
+   *         tuples of `(start_time, end_time, location, locatio_url)`
    */
   times_by_day: InputMaybe<Scalars['json']['input']>;
   /** Course times, displayed in the "Times" column in CourseTable */
@@ -5440,19 +5440,19 @@ export type SearchEvaluationNarrativesQuery = {
       __typename?: 'courses';
       evaluation_narratives: Array<{
         __typename?: 'evaluation_narratives';
-        comment: string | null;
+        comment: string;
         evaluation_question: {
           __typename?: 'evaluation_questions';
-          question_text: string | null;
+          question_text: string;
           tag: string | null;
         };
       }>;
       evaluation_ratings: Array<{
         __typename?: 'evaluation_ratings';
-        rating: any | null;
+        rating: any;
         evaluation_question: {
           __typename?: 'evaluation_questions';
-          question_text: string | null;
+          question_text: string;
           options: any | null;
           tag: string | null;
         };
@@ -5526,7 +5526,7 @@ export type ListingFragment = {
   section: string;
   skills: any;
   subject: string;
-  syllabus_url: string;
+  syllabus_url: string | null;
   times_by_day: any;
   times_summary: string;
   title: string;

--- a/frontend/src/generated/infoAttributes.json
+++ b/frontend/src/generated/infoAttributes.json
@@ -450,9 +450,5 @@
   "YSE MF Soc & Polit Ecol, Anth",
   "YSE MF Soils & Geology",
   "YSE Master's Thesis Project",
-  "YSE NF Tree Phys, Morph, Taxon",
-  "YSM MHS AdvHlthSciRsrch Elct",
-  "YSM MHS Clinical Invstgtn Elct",
-  "YSM MHS Clinical&DataSci Elct",
-  "YSM MHS Medical Education Elct"
+  "YSE NF Tree Phys, Morph, Taxon"
 ]

--- a/frontend/src/queries/queries.graphql
+++ b/frontend/src/queries/queries.graphql
@@ -1,6 +1,3 @@
-# Note: these aren't actually used directly. Instead, we use
-# graphql-codegen to create typescript and apollo bindings.
-# These can be found in the "generated" directory.
 query SameCourseOrProfOfferings(
   $same_course_id: Int!
   $professor_ids: [String!]
@@ -32,18 +29,19 @@ query SearchEvaluationNarratives($season_code: String, $crn: Int) {
   ) {
     crn
     course {
-      evaluation_narratives_aggregate {
-        nodes {
-          comment
-          evaluation_question {
-            question_text
-          }
+      evaluation_narratives {
+        comment
+        evaluation_question {
+          question_text
+          tag
         }
       }
       evaluation_ratings {
         rating
         evaluation_question {
           question_text
+          options
+          tag
         }
       }
     }

--- a/frontend/src/utilities/constants.ts
+++ b/frontend/src/utilities/constants.ts
@@ -393,53 +393,6 @@ export const extraInfo: { [key in Listing['extra_info']]: string } = {
   NUMBER_CHANGED: 'NUMBER CHANGED',
 };
 
-export const evalQuestions = {
-  assessment: {
-    question: 'What is your overall assessment of this course?',
-    labels: ['poor', 'fair', 'good', 'very good', 'excellent'],
-    title: 'Overall',
-  },
-  workload: {
-    question:
-      'Relative to other courses you have taken at Yale, the workload of this course was:',
-    labels: ['much less', 'less', 'same', 'greater', 'much greater'],
-    title: 'Workload',
-  },
-  engagement: {
-    question: 'Your level of engagement with the course was:',
-    labels: ['very low', 'low', 'medium', 'high', 'very high'],
-    title: 'Engagement',
-  },
-  organized: {
-    question: 'The course was well organized to facilitate student learning.',
-    labels: [
-      'strongly disagree',
-      'disagree',
-      'neutral',
-      'agree',
-      'strongly agree',
-    ],
-    title: 'Organization',
-  },
-  feedback: {
-    question: 'I received clear feedback that improved my learning.',
-    labels: [
-      'strongly disagree',
-      'disagree',
-      'neutral',
-      'agree',
-      'strongly agree',
-    ],
-    title: 'Feedback Clarity',
-  },
-  challenge: {
-    question:
-      'Relative to other courses you have taken at Yale, the level of intellectual challenge of this course was:',
-    labels: ['much less', 'less', 'same', 'greater', 'much greater'],
-    title: 'Intellectual Challenge',
-  },
-};
-
 export const worksheetColors = [
   '#31a4d4',
   '#2cafb7',

--- a/frontend/src/utilities/constants.ts
+++ b/frontend/src/utilities/constants.ts
@@ -393,6 +393,23 @@ export const extraInfo: { [key in Listing['extra_info']]: string } = {
   NUMBER_CHANGED: 'NUMBER CHANGED',
 };
 
+// This is the preferred order in which they will be displayed
+export const evalQuestionTags = [
+  'Overall',
+  'Workload',
+  'Engagement',
+  'Organization',
+  'Feedback',
+  'Intellectual challenge',
+  'Summary',
+  'Recommend',
+  'Skills',
+  'Strengths/weaknesses',
+  'Available resources',
+  'Major',
+  'Professor',
+];
+
 export const worksheetColors = [
   '#31a4d4',
   '#2cafb7',


### PR DESCRIPTION
Use the tags/question text returned by the api, instead of manually building our own text table.