### PR TITLE
docs: make the prefrosh FAQ link PROMINENT AND CLEAR

### DIFF
--- a/frontend/src/pages/Challenge.tsx
+++ b/frontend/src/pages/Challenge.tsx
@@ -223,11 +223,7 @@ function Challenge() {
         <TextComponent type="secondary">
           <p className="mb-2">
             You are seeing this page because we cannot automatically confirm
-            that you have access to course evaluations. See our{' '}
-            <NavLink to="/faq#how_do_i_verify_access_to_course_evaluations">
-              FAQ
-            </NavLink>{' '}
-            for more information.
+            that you have access to course evaluations.
           </p>
           <p className="mb-2">
             To confirm access, we ask that you retrieve the number of people who
@@ -235,12 +231,16 @@ function Challenge() {
             If your responses match the values in our database, you'll be good
             to go!
           </p>
-          <p className="mb-2">
-            If the challenge is not working for you, please{' '}
-            <a href="mailto:coursetable.at.yale@gmail.com">
-              let us know via email
-            </a>{' '}
-            and we can grant you access manually.
+          <p className="mb-2 fw-bold">
+            Are you an incoming first year? Please review the{' '}
+            <NavLink to="/faq#im_a_new_admit_and_i_dont_have_access_to_evaluations">
+              FAQ
+            </NavLink>{' '}
+            before contacting us. You can also find other information about the{' '}
+            <NavLink to="/faq#how_do_i_verify_access_to_course_evaluations">
+              verification process
+            </NavLink>
+            .
           </p>
         </TextComponent>
         {/* Track number of attempts */}
@@ -264,7 +264,7 @@ function Challenge() {
             {resBody.courseInfo.map((course, index) => (
               <Form.Group controlId={`question#${index + 1}`} key={index}>
                 {/* Course Title */}
-                <Row className="mx-auto">
+                <div className="mx-auto">
                   <strong>
                     <a
                       href={course.courseOceUrl}
@@ -278,9 +278,9 @@ function Challenge() {
                       />
                     </a>
                   </strong>
-                </Row>
+                </div>
                 {/* Question with link to OCE Page */}
-                <Row className="mx-auto mb-1">
+                <div className="mx-auto mb-1">
                   How many students responded to the&nbsp;
                   <span className="fw-bold">"overall assessment"</span>
                   &nbsp;question with&nbsp;
@@ -288,10 +288,11 @@ function Challenge() {
                     "{ratingOptions[course.courseRatingIndex]}"
                   </span>
                   ?
-                </Row>
+                </div>
                 {/* Number Input Box */}
                 <Form.Control
                   type="number"
+                  className="mb-3"
                   required
                   placeholder="Number of students"
                   value={answers[index]!.answer}

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -168,12 +168,18 @@ const faqs = [
             <NavLink to="/challenge" onClick={scrollToTop}>
               challenge
             </NavLink>{' '}
-            to verify your access. If the challenge is not working for you,
-            please{' '}
-            <a href="mailto:coursetable.at.yale@gmail.com">
-              let us know via email
-            </a>{' '}
-            and we can grant you access manually.
+            to verify your access.
+            <p className="fw-bold">
+              Are you a prefrosh? Read the next FAQ item please.
+            </p>
+            <p>
+              If you are not a prefrosh and the challenge is not working for
+              you, please{' '}
+              <a href="mailto:coursetable.at.yale@gmail.com">
+                let us know via email
+              </a>{' '}
+              and we may grant you access manually.
+            </p>
           </>
         ),
       },
@@ -181,19 +187,40 @@ const faqs = [
         title: "I'm a new admit and I don't have access to evaluations.",
         contents: (
           <>
-            Every March to May, we receive lots of access requests from prefrosh
-            students. We have now decided to respect Yale's matriculation
-            process and not manually grant access in these circumstances. In
-            July/August, you should log out and log in again on CourseTable to
-            refresh your authentication status. Please only let us know if you
-            still cannot access evaluations afterwards. Before that, you can
-            still use CourseTable to get a sense of what courses there are, but
-            here's our suggestion:
-            <br />
-            <b>
+            <p>
+              Every March to July, we receive lots of access requests from
+              prefrosh students. We have now decided to respect Yale's
+              matriculation process and not manually grant access in these
+              circumstances.
+            </p>
+            <p className="fw-bold">
+              We don't know exactly when Yale grants access to OCE, but if you
+              cannot access the following website:{' '}
+              <a
+                href="https://oce.app.yale.edu/ocedashboard/studentViewer"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                https://oce.app.yale.edu/ocedashboard/studentViewer
+              </a>{' '}
+              please do not ask us to manually grant you access.
+            </p>
+            <p>
+              In July/August, once you do have access, you should log out and
+              log in again on CourseTable to refresh your authentication status.
+              Please only let us know if: (1) you can access OCE (2) you have
+              logged out and logged in again (3) you have tried{' '}
+              <NavLink to="/challenge" onClick={scrollToTop}>
+                the challenge
+              </NavLink>{' '}
+              and for whatever reason it still doesn't work. Before that, you
+              can still use CourseTable to get a sense of what courses there
+              are, but here's our suggestion:
+            </p>
+            <p className="fw-bold">
               Congratulations on your admission. Now take a break from academics
               while you can. Go out! Have fun! Forget about school!
-            </b>
+            </p>
           </>
         ),
       },

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -189,9 +189,8 @@ const faqs = [
           <>
             <p>
               Every March to July, we receive lots of access requests from
-              prefrosh students. We have now decided to respect Yale's
-              matriculation process and not manually grant access in these
-              circumstances.
+              prefrosh students. We respect Yale's matriculation process and do
+              not manually override your access status in these circumstances.
             </p>
             <p className="fw-bold">
               We don't know exactly when Yale grants access to OCE, but if you


### PR DESCRIPTION
We receive too many emails from prefroshes; they are clearly not reading our FAQ.