### PR TITLE
feat: link to course prereqs

### DIFF
--- a/frontend/src/components/CourseModal/CourseModal.tsx
+++ b/frontend/src/components/CourseModal/CourseModal.tsx
@@ -313,8 +313,10 @@ function CourseModal() {
         </Modal.Header>
         {view === 'overview' ? (
           <CourseModalOverview
-            onNavigation={(l) => {
-              user.hasEvals ? setView('evals') : setView('overview');
+            onNavigation={(l, goToEvals) => {
+              user.hasEvals && goToEvals
+                ? setView('evals')
+                : setView('overview');
               if (
                 l.crn === listing.crn &&
                 l.season_code === listing.season_code

--- a/frontend/src/components/CourseModal/CourseModalOverview.tsx
+++ b/frontend/src/components/CourseModal/CourseModalOverview.tsx
@@ -13,7 +13,7 @@ function CourseModalOverview({
   onNavigation,
   header,
 }: {
-  readonly onNavigation: (x: CourseModalHeaderData) => void;
+  readonly onNavigation: (x: CourseModalHeaderData, goToEvals: boolean) => void;
   readonly header: CourseModalHeaderData;
 }) {
   const user = useStore((state) => state.user);
@@ -43,7 +43,7 @@ function CourseModalOverview({
     <Modal.Body>
       <Row className="m-auto">
         <Col md={7} className="px-0 mt-0 mb-3">
-          <OverviewInfo data={data} />
+          <OverviewInfo onNavigation={onNavigation} data={data} />
         </Col>
         <Col md={5} className="px-0 my-0">
           <OverviewRatings onNavigation={onNavigation} data={data} />

--- a/frontend/src/components/CourseModal/OverviewInfo.module.css
+++ b/frontend/src/components/CourseModal/OverviewInfo.module.css
@@ -24,6 +24,12 @@
   margin-top: 0.5rem;
 }
 
+.requirements a,
+.requirements .loadingLink {
+  color: rgb(252 105 105);
+  text-decoration: underline;
+}
+
 .friendsList {
   list-style: none;
   margin: 0;

--- a/frontend/src/components/CourseModal/OverviewInfo.tsx
+++ b/frontend/src/components/CourseModal/OverviewInfo.tsx
@@ -131,11 +131,13 @@ type Segment =
 
 function parsePrereqs(requirements: string | null) {
   if (!requirements) return null;
+  // We don't want to match "and 223", but we want to match "math 223"
+  // We want to match "CHEM 134L" but not "CPSC 223a" (CPSC 381 says this)
   const codePattern =
-    /\b(?<subject>(?!and|AND)[A-Za-z&]{3,4}) ?(?<number>\d{3,4})(?!\d)/uy;
+    /\b(?<subject>(?!and|AND)[A-Za-z&]{3,4}) ?(?<number>\d{3,4}[A-Z]?)(?!\d)/uy;
   // Prereqs often say "MATH 225 or 226" and we want to match on "226", where
   // the subject is implied (taken from the previous match)
-  const partialCodePattern = /\b\d{3,4}(?!\d)/uy;
+  const partialCodePattern = /\b\d{3,4}[A-Z]?(?!\d)/uy;
   let lastSubject = '';
   const segments: Segment[] = [];
   let lastIndex = 0;

--- a/frontend/src/components/CourseModal/OverviewRatings.tsx
+++ b/frontend/src/components/CourseModal/OverviewRatings.tsx
@@ -118,7 +118,7 @@ function CourseLink({
   readonly listing: SameCourseOrProfOfferingsQuery['self'][0];
   readonly course: RelatedCourseInfoFragment;
   readonly filter: Filter;
-  readonly onNavigation: (x: CourseModalHeaderData) => void;
+  readonly onNavigation: (x: CourseModalHeaderData, goToEvals: boolean) => void;
 }) {
   const [searchParams] = useSearchParams();
   // Note, we purposefully use the listing data fetched from GraphQL instead
@@ -155,7 +155,7 @@ function CourseLink({
         className={clsx(styles.ratingBubble, 'p-0 me-3 text-center')}
         to={createCourseModalLink(targetListingDefinite, searchParams)}
         onClick={() => {
-          onNavigation(targetListingDefinite);
+          onNavigation(targetListingDefinite, true);
         }}
       >
         <strong>{toSeasonString(course.season_code)}</strong>
@@ -178,7 +178,7 @@ function CourseLink({
                 className="d-block"
                 to={createCourseModalLink(l, searchParams)}
                 onClick={() => {
-                  onNavigation(l);
+                  onNavigation(l, true);
                 }}
               >
                 {l.course_code}
@@ -234,7 +234,7 @@ function OverviewRatings({
   onNavigation,
   data,
 }: {
-  readonly onNavigation: (x: CourseModalHeaderData) => void;
+  readonly onNavigation: (x: CourseModalHeaderData, goToEvals: boolean) => void;
   readonly data: SameCourseOrProfOfferingsQuery;
 }) {
   const user = useStore((state) => state.user);

--- a/frontend/src/generated/graphql-types.ts
+++ b/frontend/src/generated/graphql-types.ts
@@ -10606,3 +10606,39 @@ export type SearchEvaluationNarrativesQuery = {
     };
   }>;
 };
+
+export type PrereqLinkInfoQueryVariables = Exact<{
+  course_codes: InputMaybe<
+    Array<Scalars['String']['input']> | Scalars['String']['input']
+  >;
+}>;
+
+export type PrereqLinkInfoQuery = {
+  __typename?: 'query_root';
+  listings: Array<{
+    __typename?: 'listings';
+    season_code: Season;
+    crn: Crn;
+    course_code: string;
+    section: string;
+    course: {
+      __typename?: 'courses';
+      title: string;
+      skills: StringArr;
+      areas: StringArr;
+      extra_info: ExtraInfo;
+      description: string | null;
+      times_by_day: TimesByDay;
+      same_course_id: number;
+      listings: Array<{
+        __typename?: 'listings';
+        course_code: string;
+        crn: Crn;
+      }>;
+      course_professors: Array<{
+        __typename?: 'course_professors';
+        professor: { __typename?: 'professors'; professor_id: number };
+      }>;
+    };
+  }>;
+};

--- a/frontend/src/queries/graphql-queries.graphql
+++ b/frontend/src/queries/graphql-queries.graphql
@@ -113,3 +113,30 @@ query SearchEvaluationNarratives($season_code: String, $crn: Int) {
     }
   }
 }
+
+query PrereqLinkInfo($course_codes: [String!]) {
+  listings(where: { course_code: { _in: $course_codes } }) {
+    course {
+      title
+      skills
+      areas
+      extra_info
+      description
+      times_by_day
+      same_course_id
+      listings {
+        course_code
+        crn
+      }
+      course_professors {
+        professor {
+          professor_id
+        }
+      }
+    }
+    season_code
+    crn
+    course_code
+    section
+  }
+}

--- a/frontend/src/queries/graphql-queries.ts
+++ b/frontend/src/queries/graphql-queries.ts
@@ -265,3 +265,97 @@ export type SearchEvaluationNarrativesQueryResult = Apollo.QueryResult<
   Types.SearchEvaluationNarrativesQuery,
   Types.SearchEvaluationNarrativesQueryVariables
 >;
+export const PrereqLinkInfoDocument = gql`
+  query PrereqLinkInfo($course_codes: [String!]) {
+    listings(where: { course_code: { _in: $course_codes } }) {
+      course {
+        title
+        skills
+        areas
+        extra_info
+        description
+        times_by_day
+        same_course_id
+        listings {
+          course_code
+          crn
+        }
+        course_professors {
+          professor {
+            professor_id
+          }
+        }
+      }
+      season_code
+      crn
+      course_code
+      section
+    }
+  }
+`;
+
+/**
+ * __usePrereqLinkInfoQuery__
+ *
+ * To run a query within a React component, call `usePrereqLinkInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePrereqLinkInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePrereqLinkInfoQuery({
+ *   variables: {
+ *      course_codes: // value for 'course_codes'
+ *   },
+ * });
+ */
+export function usePrereqLinkInfoQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    Types.PrereqLinkInfoQuery,
+    Types.PrereqLinkInfoQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    Types.PrereqLinkInfoQuery,
+    Types.PrereqLinkInfoQueryVariables
+  >(PrereqLinkInfoDocument, options);
+}
+export function usePrereqLinkInfoLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    Types.PrereqLinkInfoQuery,
+    Types.PrereqLinkInfoQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    Types.PrereqLinkInfoQuery,
+    Types.PrereqLinkInfoQueryVariables
+  >(PrereqLinkInfoDocument, options);
+}
+export function usePrereqLinkInfoSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    Types.PrereqLinkInfoQuery,
+    Types.PrereqLinkInfoQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    Types.PrereqLinkInfoQuery,
+    Types.PrereqLinkInfoQueryVariables
+  >(PrereqLinkInfoDocument, options);
+}
+export type PrereqLinkInfoQueryHookResult = ReturnType<
+  typeof usePrereqLinkInfoQuery
+>;
+export type PrereqLinkInfoLazyQueryHookResult = ReturnType<
+  typeof usePrereqLinkInfoLazyQuery
+>;
+export type PrereqLinkInfoSuspenseQueryHookResult = ReturnType<
+  typeof usePrereqLinkInfoSuspenseQuery
+>;
+export type PrereqLinkInfoQueryResult = Apollo.QueryResult<
+  Types.PrereqLinkInfoQuery,
+  Types.PrereqLinkInfoQueryVariables
+>;


### PR DESCRIPTION
Fixes https://github.com/coursetable/coursetable/issues/1451

I've tried the following:

- https://prereq-link.preview.coursetable.com/catalog?course-modal=202403-10123
- https://prereq-link.preview.coursetable.com/catalog?course-modal=202403-10807
- https://prereq-link.preview.coursetable.com/catalog?course-modal=202403-10811
- https://prereq-link.preview.coursetable.com/catalog?course-modal=202501-21364
- https://prereq-link.preview.coursetable.com/catalog?course-modal=202403-14304
- https://prereq-link.preview.coursetable.com/catalog?course-modal=202501-20177