### PR TITLE
fix: filter graduate course using school

### DIFF
--- a/frontend/src/utilities/course.ts
+++ b/frontend/src/utilities/course.ts
@@ -360,8 +360,8 @@ type CourseWithEnrolled = {
   last_enrollment_same_professors?: boolean | null;
 };
 
-export function isGraduate(listing: Pick<Listings, 'number'>): boolean {
-  return Number(listing.number.replace(/\D/gu, '')) >= 500;
+export function isGraduate(listing: Pick<Listings, 'school'>): boolean {
+  return listing.school !== "YC";
 }
 
 export function isDiscussionSection(

--- a/frontend/src/utilities/course.ts
+++ b/frontend/src/utilities/course.ts
@@ -361,7 +361,7 @@ type CourseWithEnrolled = {
 };
 
 export function isGraduate(listing: Pick<Listings, 'school'>): boolean {
-  return listing.school !== "YC";
+  return listing.school !== 'YC';
 }
 
 export function isDiscussionSection(


### PR DESCRIPTION
Changing the filtering logic function of isGraduate from filter by the course number to the school. 