### PR TITLE
refactor: completely rework memoized values in zustand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,7 @@
         "lodash.throttle": "^4.1.1",
         "lz-string": "^1.5.0",
         "mark.js": "^8.11.1",
+        "proxy-memoize": "^3.0.1",
         "pulltorefreshjs": "^0.1.22",
         "quist": "^0.4.0",
         "rc-slider": "^11.1.8",
@@ -2537,7 +2538,11 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "proxy-compare": ["proxy-compare@3.0.1", "", {}, "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "proxy-memoize": ["proxy-memoize@3.0.1", "", { "dependencies": { "proxy-compare": "^3.0.0" } }, "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g=="],
 
     "prr": ["prr@1.0.1", "", {}, "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "lodash.throttle": "^4.1.1",
     "lz-string": "^1.5.0",
     "mark.js": "^8.11.1",
+    "proxy-memoize": "^3.0.1",
     "pulltorefreshjs": "^0.1.22",
     "quist": "^0.4.0",
     "rc-slider": "^11.1.8",

--- a/frontend/src/components/Worksheet/CalendarEvent.tsx
+++ b/frontend/src/components/Worksheet/CalendarEvent.tsx
@@ -52,7 +52,9 @@ export function CalendarEventBody({ event }: { readonly event: RBCEvent }) {
 
 function CalendarEvent({ event }: { readonly event: RBCEvent }) {
   const { listing } = event;
-  const isReadonlyWorksheet = useStore((state) => state.isReadonlyWorksheet);
+  const isReadonlyWorksheet = useStore((state) =>
+    state.worksheetMemo.getIsReadonlyWorksheet(state),
+  );
 
   return (
     <>

--- a/frontend/src/components/Worksheet/NavbarWorksheetSearch.tsx
+++ b/frontend/src/components/Worksheet/NavbarWorksheetSearch.tsx
@@ -27,7 +27,7 @@ export function NavbarWorksheetSearch() {
       changeWorksheetView: state.changeWorksheetView,
       viewedPerson: state.viewedPerson,
       changeViewedPerson: state.changeViewedPerson,
-      isExoticWorksheet: state.isExoticWorksheet,
+      isExoticWorksheet: state.worksheetMemo.getIsExoticWorksheet(state),
       exitExoticWorksheet: state.exitExoticWorksheet,
     })),
   );

--- a/frontend/src/components/Worksheet/SeasonDropdown.tsx
+++ b/frontend/src/components/Worksheet/SeasonDropdown.tsx
@@ -12,7 +12,7 @@ import { PopoutSelect } from '../Search/PopoutSelect';
 function SeasonDropdownDesktop() {
   const { seasonCodes, viewedSeason, changeViewedSeason } = useStore(
     useShallow((state) => ({
-      seasonCodes: state.seasonCodes,
+      seasonCodes: state.worksheetMemo.getSeasonCodes(state),
       viewedSeason: state.viewedSeason,
       changeViewedSeason: state.changeViewedSeason,
     })),
@@ -55,7 +55,7 @@ function SeasonDropdownDesktop() {
 function SeasonDropdownMobile() {
   const { seasonCodes, viewedSeason, changeViewedSeason } = useStore(
     useShallow((state) => ({
-      seasonCodes: state.seasonCodes,
+      seasonCodes: state.worksheetMemo.getSeasonCodes(state),
       viewedSeason: state.viewedSeason,
       changeViewedSeason: state.changeViewedSeason,
     })),

--- a/frontend/src/components/Worksheet/URLExportButton.tsx
+++ b/frontend/src/components/Worksheet/URLExportButton.tsx
@@ -9,7 +9,7 @@ export default function URLExportButton() {
   const { viewedSeason, viewedWorksheetName, courses } = useStore(
     useShallow((state) => ({
       viewedSeason: state.viewedSeason,
-      viewedWorksheetName: state.viewedWorksheetName,
+      viewedWorksheetName: state.worksheetMemo.getViewedWorksheetName(state),
       courses: state.courses,
     })),
   );

--- a/frontend/src/components/Worksheet/WorksheetCalendarList.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendarList.tsx
@@ -41,9 +41,10 @@ function WorksheetCalendarList() {
       courses: state.courses,
       viewedSeason: state.viewedSeason,
       viewedWorksheetNumber: state.viewedWorksheetNumber,
-      isReadonlyWorksheet: state.isReadonlyWorksheet,
-      isExoticWorksheet: state.isExoticWorksheet,
-      isViewedWorksheetPrivate: state.isViewedWorksheetPrivate,
+      isReadonlyWorksheet: state.worksheetMemo.getIsReadonlyWorksheet(state),
+      isExoticWorksheet: state.worksheetMemo.getIsExoticWorksheet(state),
+      isViewedWorksheetPrivate:
+        state.worksheetMemo.getIsViewedWorksheetPrivate(state),
       viewedPerson: state.viewedPerson,
     })),
   );

--- a/frontend/src/components/Worksheet/WorksheetHideButton.tsx
+++ b/frontend/src/components/Worksheet/WorksheetHideButton.tsx
@@ -29,7 +29,7 @@ export default function WorksheetHideButton({
       viewedSeason: state.viewedSeason,
       viewedWorksheetNumber: state.viewedWorksheetNumber,
       viewedPerson: state.viewedPerson,
-      isReadonlyWorksheet: state.isReadonlyWorksheet,
+      isReadonlyWorksheet: state.worksheetMemo.getIsReadonlyWorksheet(state),
     })),
   );
   if (isReadonlyWorksheet || viewedPerson !== 'me') return null;

--- a/frontend/src/components/Worksheet/WorksheetStats.tsx
+++ b/frontend/src/components/Worksheet/WorksheetStats.tsx
@@ -89,7 +89,7 @@ export default function WorksheetStats() {
   const { courses, isExoticWorksheet, exitExoticWorksheet } = useStore(
     useShallow((state) => ({
       courses: state.courses,
-      isExoticWorksheet: state.isExoticWorksheet,
+      isExoticWorksheet: state.worksheetMemo.getIsExoticWorksheet(state),
       exitExoticWorksheet: state.exitExoticWorksheet,
     })),
   );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,7 @@ import {
   matchRoutes,
 } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
-import { enableMapSet } from 'immer';
+import { enableMapSet, setAutoFreeze } from 'immer';
 
 // Globals has to be imported first, because it contains all the base CSS!
 // eslint-disable-next-line import/order
@@ -17,6 +17,7 @@ import { isDev } from './config';
 import { TutorialProvider } from './contexts/tutorialContext';
 
 enableMapSet();
+setAutoFreeze(false);
 
 Sentry.init({
   enabled: !isDev,

--- a/frontend/src/pages/Worksheet.tsx
+++ b/frontend/src/pages/Worksheet.tsx
@@ -33,7 +33,7 @@ function Worksheet() {
       worksheetLoading: state.worksheetLoading,
       worksheetError: state.worksheetError,
       worksheetView: state.worksheetView,
-      isExoticWorksheet: state.isExoticWorksheet,
+      isExoticWorksheet: state.worksheetMemo.getIsExoticWorksheet(state),
     })),
   );
   const [expanded, setExpanded] = useState(false);

--- a/frontend/src/slices/WorksheetSlice.ts
+++ b/frontend/src/slices/WorksheetSlice.ts
@@ -1,9 +1,9 @@
 import { decompressFromEncodedURIComponent } from 'lz-string';
+import { memoize } from 'proxy-memoize';
 import { toast } from 'react-toastify';
 import { z } from 'zod';
 import type { StateCreator } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { shallow } from 'zustand/shallow';
 import { CUR_SEASON } from '../config';
 import {
   seasons as allSeasons,
@@ -46,13 +46,10 @@ export type ExoticWorksheet = z.infer<typeof exoticWorksheetSchema>;
 
 // Slice Types
 interface WorksheetState {
-  curWorksheet: UserWorksheets;
-
   // These define which courses the store contains
   viewedPerson: 'me' | NetId;
   viewedSeason: Season;
   viewedWorksheetNumber: number;
-  viewedWorksheetName: string;
 
   // An exotic worksheet is one that is imported via the URL or file upload.
   // Exotic worksheets do not have a corresponding worksheet in the worksheets
@@ -60,11 +57,6 @@ interface WorksheetState {
   exoticWorksheet:
     | { data: ExoticWorksheet; worksheets: UserWorksheets }
     | undefined;
-  isExoticWorksheet: boolean;
-  isViewedWorksheetPrivate: boolean;
-  // A readonly worksheet is anything that doesn't belong to the user—either
-  // exotic or a friend's worksheet.
-  isReadonlyWorksheet: boolean;
 
   // Affect visual display
   worksheetView: WorksheetView;
@@ -80,8 +72,6 @@ interface WorksheetState {
 }
 
 interface WorksheetActions {
-  setCurWorksheet: (worksheet: UserWorksheets) => void;
-
   changeViewedPerson: (newPerson: WorksheetState['viewedPerson']) => void;
   changeViewedSeason: (seasonCode: WorksheetState['viewedSeason']) => void;
   changeViewedWorksheetNumber: (
@@ -101,8 +91,6 @@ interface WorksheetActions {
   changeWorksheetView: (view: WorksheetState['worksheetView']) => void;
   setHoverCourse: (course: WorksheetState['hoverCourse']) => void;
 
-  setSeasonCodes: (seasons: Season[]) => void;
-
   setWorksheetInfo: (
     courses: WorksheetState['courses'],
     worksheetLoading: WorksheetState['worksheetLoading'],
@@ -110,7 +98,22 @@ interface WorksheetActions {
   ) => void;
 }
 
-export interface WorksheetSlice extends WorksheetState, WorksheetActions {}
+// Memoized Values
+interface WorksheetSliceMemo {
+  worksheetMemo: {
+    getCurWorksheet: (state: Store) => UserWorksheets;
+    getSeasonCodes: (state: Store) => Season[];
+    getIsExoticWorksheet: (state: Store) => boolean;
+    getIsReadonlyWorksheet: (state: Store) => boolean;
+    getViewedWorksheetName: (state: Store) => string;
+    getIsViewedWorksheetPrivate: (state: Store) => boolean;
+  };
+}
+
+export interface WorksheetSlice
+  extends WorksheetState,
+    WorksheetActions,
+    WorksheetSliceMemo {}
 
 // Utility Functions
 function seasonsWithDataFirst(
@@ -167,10 +170,6 @@ export const createWorksheetSlice: StateCreator<
   const parsedExoticWorksheet = parseCoursesFromURL();
 
   return {
-    curWorksheet: new Map(),
-    setCurWorksheet(worksheet) {
-      set({ curWorksheet: worksheet });
-    },
     viewedPerson: 'me',
     viewedSeason: CUR_SEASON,
     viewedWorksheetNumber: 0,
@@ -189,13 +188,9 @@ export const createWorksheetSlice: StateCreator<
       return get().viewedWorksheetNumber;
     },
     exoticWorksheet: parsedExoticWorksheet,
-    isExoticWorksheet: Boolean(parsedExoticWorksheet),
-    isReadonlyWorksheet: Boolean(parsedExoticWorksheet),
     exitExoticWorksheet() {
       set({
         exoticWorksheet: undefined,
-        isExoticWorksheet: false,
-        isReadonlyWorksheet: false,
       });
       const searchParams = new URLSearchParams(window.location.search);
       searchParams.delete('ws');
@@ -215,114 +210,56 @@ export const createWorksheetSlice: StateCreator<
       set({ hoverCourse: course });
     },
     seasonCodes: [],
-    setSeasonCodes(seasons) {
-      set({ seasonCodes: seasons });
-    },
     courses: [],
-    viewedWorksheetName: 'Main Worksheet',
-    isViewedWorksheetPrivate: false,
     worksheetLoading: false,
     worksheetError: null,
     setWorksheetInfo(courses, worksheetLoading, worksheetError) {
       set({ courses, worksheetLoading, worksheetError });
     },
+    worksheetMemo: {
+      getCurWorksheet: memoize(
+        (state: Store): UserWorksheets =>
+          ((state.viewedPerson === 'me'
+            ? state.worksheets
+            : state.friends?.[state.viewedPerson]?.worksheets) ??
+            new Map()) as UserWorksheets,
+      ),
+      getSeasonCodes: memoize((state: Store) =>
+        seasonsWithDataFirst(allSeasons, state.worksheets),
+      ),
+      getIsExoticWorksheet: memoize((state: Store) =>
+        Boolean(state.exoticWorksheet),
+      ),
+      // A readonly worksheet is anything that doesn't belong to the user—either
+      // exotic or a friend's worksheet.
+      getIsReadonlyWorksheet: memoize(
+        (state: Store) =>
+          state.worksheetMemo.getIsExoticWorksheet(state) ||
+          state.viewedPerson !== 'me',
+      ),
+      getViewedWorksheetName: memoize(
+        (state: Store) =>
+          state.exoticWorksheet?.data.name ??
+          state.worksheetMemo
+            .getCurWorksheet(state)
+            .get(state.viewedSeason)
+            ?.get(state.viewedWorksheetNumber)?.name ??
+          (state.viewedWorksheetNumber === 0
+            ? 'Main Worksheet'
+            : 'Unnamed Worksheet'),
+      ),
+      getIsViewedWorksheetPrivate: memoize(
+        (state: Store) =>
+          state.worksheetMemo
+            .getCurWorksheet(state)
+            .get(state.viewedSeason)
+            ?.get(state.viewedWorksheetNumber)?.private ?? false,
+      ),
+    },
   };
 };
 
-// Subscriptions and Effects
-// Although not ideal, a subscription is the simplest way
-// to handle computed values in a memoized fashion in Zustand.
 // Effects should be used for values with React dependencies
-export const useWorksheetSubscriptions = () => {
-  const { setCurWorksheet, setSeasonCodes } = useStore.getState(); // Non-reactive function references
-
-  useStore.subscribe(
-    (state) => ({
-      worksheets: state.worksheets,
-      friends: state.friends,
-      viewedPerson: state.viewedPerson,
-    }),
-    ({ worksheets, friends, viewedPerson }) => {
-      const whenNotDefined: UserWorksheets = new Map();
-      if (viewedPerson === 'me') setCurWorksheet(worksheets ?? whenNotDefined);
-      else
-        setCurWorksheet(friends?.[viewedPerson]?.worksheets ?? whenNotDefined);
-    },
-    { equalityFn: shallow },
-  );
-
-  useStore.subscribe(
-    (state) => ({
-      curWorksheet: state.curWorksheet,
-      viewedSeason: state.viewedSeason,
-      viewedWorksheetNumber: state.viewedWorksheetNumber,
-    }),
-    ({ curWorksheet, viewedSeason, viewedWorksheetNumber }) => {
-      useStore.setState({
-        isViewedWorksheetPrivate:
-          curWorksheet.get(viewedSeason)?.get(viewedWorksheetNumber)?.private ??
-          false,
-      });
-    },
-    { equalityFn: shallow },
-  );
-
-  useStore.subscribe(
-    (state) => ({
-      exoticWorksheet: state.exoticWorksheet,
-      curWorksheet: state.curWorksheet,
-      viewedSeason: state.viewedSeason,
-      viewedWorksheetNumber: state.viewedWorksheetNumber,
-    }),
-    ({
-      exoticWorksheet,
-      curWorksheet,
-      viewedSeason,
-      viewedWorksheetNumber,
-    }) => {
-      useStore.setState({
-        viewedWorksheetName:
-          exoticWorksheet?.data.name ??
-          curWorksheet.get(viewedSeason)?.get(viewedWorksheetNumber)?.name ??
-          (viewedWorksheetNumber === 0
-            ? 'Main Worksheet'
-            : 'Unnamed Worksheet'),
-      });
-    },
-    {
-      equalityFn: shallow,
-    },
-  );
-
-  useStore.subscribe(
-    (state) => ({
-      isExoticWorksheet: state.isExoticWorksheet,
-      viewedPerson: state.viewedPerson,
-    }),
-    ({ isExoticWorksheet, viewedPerson }) => {
-      useStore.setState({
-        isReadonlyWorksheet: isExoticWorksheet || viewedPerson !== 'me',
-      });
-    },
-    { equalityFn: shallow },
-  );
-
-  useStore.subscribe(
-    (state) => state.exoticWorksheet,
-    (exoticWorksheet) =>
-      useStore.setState({ isExoticWorksheet: Boolean(exoticWorksheet) }),
-    { equalityFn: shallow },
-  );
-
-  useStore.subscribe(
-    (state) => state.worksheets,
-    (worksheets) => {
-      setSeasonCodes(seasonsWithDataFirst(allSeasons, worksheets));
-    },
-    { equalityFn: shallow },
-  );
-};
-
 export const useWorksheetEffects = () => {
   const {
     exoticWorksheet,
@@ -333,12 +270,13 @@ export const useWorksheetEffects = () => {
   } = useStore(
     useShallow((state) => ({
       exoticWorksheet: state.exoticWorksheet,
-      curWorksheet: state.curWorksheet,
+      curWorksheet: state.worksheetMemo.getCurWorksheet(state),
       viewedSeason: state.viewedSeason,
       viewedWorksheetNumber: state.viewedWorksheetNumber,
       setWorksheetInfo: state.setWorksheetInfo,
     })),
   );
+
   const {
     loading: worksheetLoading,
     error: worksheetError,

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -21,7 +21,6 @@ import { createUserSlice, type UserSlice } from './slices/UserSlice';
 import {
   createWorksheetSlice,
   useWorksheetEffects,
-  useWorksheetSubscriptions,
   type WorksheetSlice,
 } from './slices/WorksheetSlice';
 import { pick } from './utilities/common';
@@ -128,10 +127,6 @@ const useTheme = () => {
 };
 
 export const useInitStore = () => {
-  // Subscriptions first
-  useWorksheetSubscriptions();
-
-  // Then effects
   useAuth();
   useDimensions();
   useTheme();


### PR DESCRIPTION
Relying on `memoize` from `proxy-memoize` instead of subscription pattern. Should resolve stack overflow edge cases while following a much more accurate memoization pattern.