### PR TITLE
fix: remove viewedPerson from localStorage persistence

### DIFF
--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -39,7 +39,6 @@ const basePersistKeys: (keyof Store)[] = [
   'theme',
   'coursePref',
   'professorPref',
-  'viewedPerson',
   'viewedSeason',
   'viewedWorksheetNumber',
   'worksheetView',


### PR DESCRIPTION
## Problem
The `viewedPerson` state (which friend's worksheet is being viewed) was being persisted to localStorage, meaning it would persist across browser sessions. However the choice to view a friend's worksheet should be ephemeral and session-based.

## Solution
Removed `viewedPerson` from the persist keys in the Zustand store. Now when users view a friend's worksheet, it only lasts for the current browser session and resets to viewing their own worksheet (`'me'`) when they return.