### PR TITLE
feat: standardize worksheet PNG export

### DIFF
--- a/frontend/src/components/Worksheet/CalendarEvent.tsx
+++ b/frontend/src/components/Worksheet/CalendarEvent.tsx
@@ -340,6 +340,7 @@ export function CalendarEventBody({
         {lastMod && (
           <div
             data-event-line="true"
+            data-calendar-export-omit=""
             className={clsx(
               styles.eventLine,
               hideFromLineIndex !== null &&

--- a/frontend/src/components/Worksheet/PNGExportButton.tsx
+++ b/frontend/src/components/Worksheet/PNGExportButton.tsx
@@ -18,6 +18,9 @@ const RETRY_DELAY = 100; // Delay between retries in milliseconds
 
 const EXPORT_CLASS = 'exporting-png';
 
+const EXPORT_LAYOUT_WIDTH = EXPORT_WIDTH / CANVAS_SCALE;
+const EXPORT_LAYOUT_HEIGHT = EXPORT_HEIGHT / CANVAS_SCALE;
+
 const EXPORT_BG = {
   light: '#ffffff',
   dark: '#121212',
@@ -42,6 +45,26 @@ function drawCaptureLetterboxed(
   const offsetY = (EXPORT_HEIGHT - drawH) / 2;
 
   ctx.drawImage(source, offsetX, offsetY, drawW, drawH);
+}
+
+/** Widen cloned calendar so capture matches desktop export, not viewport. */
+function applyExportLayoutToClonedCalendar(doc: Document): void {
+  const cal = doc.querySelector<HTMLElement>('.rbc-calendar');
+  if (!cal) return;
+
+  cal.style.setProperty('box-sizing', 'border-box', 'important');
+  cal.style.setProperty('width', `${EXPORT_LAYOUT_WIDTH}px`, 'important');
+  cal.style.setProperty('max-width', `${EXPORT_LAYOUT_WIDTH}px`, 'important');
+  cal.style.setProperty('min-height', `${EXPORT_LAYOUT_HEIGHT}px`, 'important');
+  cal.style.setProperty('height', 'auto', 'important');
+  cal.style.setProperty('overflow', 'visible', 'important');
+
+  let node: HTMLElement | null = cal.parentElement;
+  for (let depth = 0; node && node !== doc.body && depth < 10; depth += 1) {
+    node.style.setProperty('overflow', 'visible', 'important');
+    node.style.setProperty('max-width', 'none', 'important');
+    node = node.parentElement;
+  }
 }
 
 const loadImage = (src: string): Promise<HTMLImageElement> =>
@@ -142,6 +165,7 @@ export default function PNGExportButton() {
         onclone(doc) {
           doc.body.classList.add(EXPORT_CLASS);
           doc.documentElement.dataset.theme = theme;
+          applyExportLayoutToClonedCalendar(doc);
         },
       });
 

--- a/frontend/src/components/Worksheet/WorksheetCalendarList.module.css
+++ b/frontend/src/components/Worksheet/WorksheetCalendarList.module.css
@@ -65,8 +65,46 @@
   transform: scale(1.15);
 }
 
-.button :global(.dropdown-menu) {
-  min-width: 20rem !important;
+.exportCalendarDropdown :global(.dropdown-menu) {
+  box-sizing: border-box;
+  width: 20rem;
+  max-width: min(20rem, calc(100vw - 1.5rem));
+  min-width: 20rem;
+  max-height: none;
+  height: auto;
+  overflow: visible;
+  padding: 0;
+}
+
+.exportCalendarDropdown :global(.dropdown-item) {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  border-radius: 0;
+}
+
+.exportCalendarDropdown :global(.dropdown-item) button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0.55rem 1rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  border-radius: 0;
+}
+
+.exportCalendarDropdown :global(.dropdown-item):hover,
+.exportCalendarDropdown :global(.dropdown-item):focus-within {
+  background-color: var(--color-surface-hover);
+}
+
+.exportCalendarDropdown :global(.dropdown-item) button:hover,
+.exportCalendarDropdown :global(.dropdown-item) button:focus-visible {
+  color: inherit;
 }
 
 .importRow {

--- a/frontend/src/components/Worksheet/WorksheetCalendarList.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendarList.tsx
@@ -304,7 +304,11 @@ function WorksheetCalendarList({
                       />
                     }
                     variant="none"
-                    className={clsx(styles.button, 'w-100 btn')}
+                    className={clsx(
+                      styles.button,
+                      styles.exportCalendarDropdown,
+                      'w-100 btn',
+                    )}
                   >
                     <Dropdown.Item eventKey="1" as="div">
                       <GoogleCalendarButton />

--- a/frontend/src/components/Worksheet/react-big-calendar-override.css
+++ b/frontend/src/components/Worksheet/react-big-calendar-override.css
@@ -73,6 +73,10 @@
   display: none !important;
 }
 
+.exporting-png [data-calendar-export-omit] {
+  display: none !important;
+}
+
 .rbc-header a:hover {
   color: black !important;
   text-decoration: none !important;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -137,7 +137,7 @@ hr {
 
 .dropdown-menu {
   max-height: 50vh;
-  min-width: 0 !important;
+  min-width: 0;
   overflow: scroll;
 }
 


### PR DESCRIPTION
Standardizes the exported worksheet PNG dimensions to 1600x1000 and removes the time indicator line on download. Closes #1854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PNG exports now respect the selected theme (background and themed watermark/logo) and use a desktop-sized, centered export layout.

* **Bug Fixes**
  * Fixed letterboxed/scale issues so exported content is correctly centered and scaled.
  * Current-time indicator and designated elements are now omitted from PNG exports for cleaner images.

* **Style**
  * Export dropdown and menu styling adjusted for consistent sizing and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->