### PR TITLE
fix: use catalog URL when sharing course from modal #1875

### DIFF
--- a/frontend/src/components/CourseModal/Header/ControlsRow.tsx
+++ b/frontend/src/components/CourseModal/Header/ControlsRow.tsx
@@ -25,7 +25,7 @@ function ShareButton({
     const params = new URLSearchParams(window.location.search);
     const courseModal = params.get('course-modal');
 
-    const url = `${window.location.origin}${window.location.pathname}${
+    const url = `${window.location.origin}/catalog${
       courseModal !== null ? `?course-modal=${courseModal}` : ''
     }`;
     const textToCopy = `${listing.course_code} -- CourseTable: ${url}`;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

The template can be skipped for small and straightforward changes, such as typo fixes.
-->

## Pre-flight checklist

- [x] I have searched for potential duplicate pull requests.
- [x] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

This PR fixes/implements the following **bugs/features**

- changes course link copying from worksheet modal from "worksheet format" to "catalog format" to direct users to the catalog when sharing courses.


## Test plan (required)

Tested on several courses, copied and shared links. Link copying works when shared from multiple places. Always uses catalog instead of window.location.pathname.

Fixes #1875 