### PR TITLE
fix: gate location field behind hasEvals in course modal query

### DIFF
--- a/frontend/src/generated/graphql-types.ts
+++ b/frontend/src/generated/graphql-types.ts
@@ -3765,7 +3765,7 @@ export type CourseModalOverviewDataQuery = {
         days_of_week: number;
         start_time: string;
         end_time: string;
-        location: {
+        location?: {
           __typename?: 'locations';
           room: string | null;
           building: {

--- a/frontend/src/queries/graphql-queries.graphql
+++ b/frontend/src/queries/graphql-queries.graphql
@@ -23,7 +23,7 @@ query CourseModalOverviewData(
         days_of_week
         start_time
         end_time
-        location {
+        location @include(if: $hasEvals) {
           room
           building {
             code

--- a/frontend/src/queries/graphql-queries.ts
+++ b/frontend/src/queries/graphql-queries.ts
@@ -67,7 +67,7 @@ export const CourseModalOverviewDataDocument = gql`
           days_of_week
           start_time
           end_time
-          location {
+          location @include(if: $hasEvals) {
             room
             building {
               code


### PR DESCRIPTION
revert gql queries to use `hasEvals` to gate locations for non-signed-in users