### PR TITLE
fix: prevent course modal from reopening on first close

### DIFF
--- a/frontend/src/contexts/modalHistoryContext.tsx
+++ b/frontend/src/contexts/modalHistoryContext.tsx
@@ -2,7 +2,6 @@ import React, {
   createContext,
   useContext,
   useMemo,
-  useRef,
   useState,
   useCallback,
   useEffect,
@@ -108,7 +107,7 @@ export function ModalHistoryProvider({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const isClosingRef = useRef(false);
+  const [isClosing, setIsClosing] = useState(false);
   const courseFromURL = useCourseInfoFromURL(history.length === 0);
   const profFromURL = useProfInfoFromURL();
 
@@ -122,10 +121,10 @@ export function ModalHistoryProvider({
       !searchParams.has('course-modal') &&
       !searchParams.has('prof-modal')
     )
-      isClosingRef.current = false;
+      setIsClosing(false);
   }, [history.length, searchParams]);
 
-  if (history.length === 0 && !isClosingRef.current) {
+  if (history.length === 0 && !isClosing) {
     if (courseFromURL) setHistory([{ type: 'course', data: courseFromURL }]);
     else if (profFromURL)
       setHistory([{ type: 'professor', data: profFromURL }]);
@@ -145,7 +144,7 @@ export function ModalHistoryProvider({
     [history, setHistory],
   );
   const closeModal = useCallback(() => {
-    isClosingRef.current = true;
+    setIsClosing(true);
     setHistory([]);
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);


### PR DESCRIPTION
Course modal needed two clicks to close because of React 19 + React Router 7 timing: setSearchParams updates the URL asynchronously, so after closeModal ran there was a render where history was already empty but searchParams still had the modal param. The sync logic treated that as “open modal” and repopulated history.

this pr fixes it by tracking an isClosingRef and skipping sync from the URL until the params have actually updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented premature modal state restoration so previous state isn't reapplied when a modal closes.
  * Ensured URL parameters are reliably cleared when dismissing modals to avoid stale links.
  * Improved coordination and timing of modal open/close transitions for more consistent behavior and history restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->