### PR TITLE
fix: preserve manually granted evals on login

### DIFF
--- a/api/src/auth/auth.handlers.ts
+++ b/api/src/auth/auth.handlers.ts
@@ -66,7 +66,7 @@ export const passportConfig = (
         // Create or update user's profile
         winston.info("Creating user's profile");
 
-        const [existingUser] = await db
+        const [insertedUser] = await db
           .insert(studentBluebookSettings)
           .values({
             netId: profile.user,
@@ -74,6 +74,18 @@ export const passportConfig = (
           })
           .onConflictDoNothing()
           .returning();
+
+        const existingUser =
+          insertedUser ??
+          (await db.query.studentBluebookSettings.findFirst({
+            where: eq(studentBluebookSettings.netId, profile.user),
+            columns: {
+              email: true,
+              firstName: true,
+              lastName: true,
+              evaluationsEnabled: true,
+            },
+          }));
 
         const user = {
           netId: profile.user,


### PR DESCRIPTION
previously, when an existing user logged in, `onConflictDoNothing` returned no row, so we never read their current `evaluationsEnabled` from the DB.

now fetch the existing user from the DB when the insert conflicts so `evaluationsEnabled` is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced user authentication to more reliably retrieve and handle existing user account information during sign-in operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->