### PR TITLE
chore: 202502 eval release

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -12,7 +12,7 @@ export const GRAPHQL_API_ENDPOINT = isDev
 export const CUR_SEASON = '202601' as Season;
 
 // Courses in the current year have no evaluations yet
-export const CUR_YEAR = ['202502', '202503', '202601', '202602'] as Season[];
+export const CUR_YEAR = ['202601', '202602'] as Season[];
 
 // We use this format to avoid dealing with time zones.
 // TODO: this should be a Temporal.PlainDate


### PR DESCRIPTION
- remove 202502 and 202503 from seasons
- to merge once ferry run for 202502 evals completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to adjust the date range used in system evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->