### PR TITLE
fix: friend remove toast layout (wrap toast content in div)

### DIFF
--- a/frontend/src/components/Worksheet/NavbarWorksheetSearch.tsx
+++ b/frontend/src/components/Worksheet/NavbarWorksheetSearch.tsx
@@ -69,7 +69,7 @@ export function NavbarWorksheetSearch({
             Do you want to continue?
             <br />
             <LinkLikeText
-              className="mx-2"
+              className="me-2"
               onClick={async () => {
                 if (!isRequest && viewedPerson === friendNetId)
                   changeViewedPerson('me');
@@ -81,7 +81,6 @@ export function NavbarWorksheetSearch({
               Yes
             </LinkLikeText>
             <LinkLikeText
-              className="mx-2"
               onClick={() => {
                 toast.dismiss(`remove-${friendNetId}`);
                 resolve();


### PR DESCRIPTION
in react-toastify v11, each toast row is a horizontal flex layout: warning icon + content.

fix is to wrap the toast body in one div so the message and yes/no controls are a single flex child next to the icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the confirmation message shown when removing a friend so lines and spacing display clearly and consistently.
  * Ensured the notification's rendering structure is stable, reducing display inconsistencies in the removal confirmation dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->