### PR TITLE
fix: remove data-first ordering of seasons in worksheet view

### DIFF
--- a/frontend/src/slices/WorksheetSlice.ts
+++ b/frontend/src/slices/WorksheetSlice.ts
@@ -116,21 +116,6 @@ interface WorksheetSliceMemo {
 export interface WorksheetSlice
   extends WorksheetState, WorksheetActions, WorksheetSliceMemo {}
 
-// Utility Functions
-function seasonsWithDataFirst(
-  seasons: Season[],
-  worksheets: UserWorksheets | undefined,
-) {
-  if (!worksheets) return seasons;
-  return seasons.toSorted((a, b) => {
-    const aHasData = worksheets.has(a);
-    const bHasData = worksheets.has(b);
-    if (aHasData && !bHasData) return -1;
-    if (!aHasData && bHasData) return 1;
-    return Number(b) - Number(a);
-  });
-}
-
 export function parseCoursesFromURL(): WorksheetState['exoticWorksheet'] {
   const searchParams = new URLSearchParams(window.location.search);
   if (!searchParams.has('ws')) return undefined;
@@ -227,9 +212,7 @@ export const createWorksheetSlice: StateCreator<
           : state.friends?.[state.viewedPerson]?.worksheets) ??
           new Map()) as UserWorksheets,
     ),
-    getSeasonCodes: memoize((state: Store) =>
-      seasonsWithDataFirst(allSeasons, state.worksheets),
-    ),
+    getSeasonCodes: memoize(() => allSeasons),
     getIsExoticWorksheet: memoize((state: Store) =>
       Boolean(state.exoticWorksheet),
     ),


### PR DESCRIPTION
the most recent seasons which had no courses were showing up later in the dropdown. update it to use the same order as the catalog shows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Season display order is now consistent and static, rather than being dynamically reordered based on data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->