### PR TITLE
feat: add crimson glow border effect on page load

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -111,6 +111,54 @@ hr {
   height: 100vh;
 }
 
+#root::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  pointer-events: none;
+  border-radius: 4px;
+  animation: crimson-glow 5s ease-out forwards;
+}
+
+@keyframes crimson-glow {
+  0% {
+    box-shadow: inset 0 0 120px 40px #a51c30;
+  }
+
+  12% {
+    box-shadow: inset 0 0 40px 10px #a51c30;
+  }
+
+  25% {
+    box-shadow: inset 0 0 100px 35px #a51c30;
+  }
+
+  37% {
+    box-shadow: inset 0 0 30px 8px #a51c30;
+  }
+
+  50% {
+    box-shadow: inset 0 0 80px 30px #a51c30;
+  }
+
+  62% {
+    box-shadow: inset 0 0 20px 6px #a51c30;
+  }
+
+  75% {
+    box-shadow: inset 0 0 50px 15px #a51c30;
+  }
+
+  87% {
+    box-shadow: inset 0 0 10px 3px #a51c30;
+  }
+
+  100% {
+    box-shadow: inset 0 0 0 0 transparent;
+  }
+}
+
 #base {
   height: auto;
 }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have searched for potential duplicate pull requests.
- [x] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary
Added additional glow to the red effects to the april fools prank


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced an animated red glow overlay effect that enhances the interface with dynamic visual feedback. The overlay features a smooth animation sequence with gradual fade-out transitions, creating a striking visual element. It remains non-interactive and displays above all interface components, providing improved aesthetic appeal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->