### PR TITLE
feat(worksheet): stack concurrent courses in worksheet calendar

### DIFF
--- a/frontend/src/components/Worksheet/CalendarEvent.module.css
+++ b/frontend/src/components/Worksheet/CalendarEvent.module.css
@@ -14,6 +14,11 @@
   overflow: hidden;
 }
 
+.eventContentStack {
+  min-height: 0;
+  gap: 2px;
+}
+
 .eventLine {
   width: 100%;
   flex-shrink: 0;

--- a/frontend/src/components/Worksheet/CalendarEvent.tsx
+++ b/frontend/src/components/Worksheet/CalendarEvent.tsx
@@ -5,12 +5,14 @@ import React, {
   useLayoutEffect,
   useRef,
   useState,
+  type SyntheticEvent,
 } from 'react';
 import clsx from 'clsx';
 import { Modal } from 'react-bootstrap';
 import { BsExclamationTriangleFill } from 'react-icons/bs';
 import { FaWalking } from 'react-icons/fa';
 import chroma from 'chroma-js';
+import { OverlapStackRows } from './CalendarOverlapStack';
 import WorksheetHideButton from './WorksheetHideButton';
 import WorksheetItemActionsButton from './WorksheetItemActionsButton';
 import { useStore } from '../../store';
@@ -39,9 +41,16 @@ function formatMinutes(minutes: number) {
 export function CalendarEventBody({
   event,
   onWalkModalInteraction,
+  stackPeers,
+  onPickStackCourse,
 }: {
   readonly event: CourseRBCEvent;
   readonly onWalkModalInteraction?: (interaction: WalkModalInteraction) => void;
+  readonly stackPeers?: CourseRBCEvent[];
+  readonly onPickStackCourse?: (
+    picked: CourseRBCEvent,
+    e: SyntheticEvent,
+  ) => void;
 }) {
   const { walkBefore } = event;
   const walkBaseColor = chroma(event.color);
@@ -76,6 +85,10 @@ export function CalendarEventBody({
     : event.title;
 
   const lastMod = event.listing.course.last_updated as string | undefined;
+  const showOverlapStack =
+    stackPeers &&
+    stackPeers.length > 1 &&
+    typeof onPickStackCourse === 'function';
 
   useLayoutEffect(() => {
     if (!walkBefore) {
@@ -194,6 +207,11 @@ export function CalendarEventBody({
     const contentNode = eventContentRef.current;
     if (!contentNode) return undefined;
 
+    if (showOverlapStack) {
+      setHideFromLineIndex(null);
+      return undefined;
+    }
+
     let frame = 0;
     const measureLineHeight = (lineNode: HTMLElement) => {
       const clone = lineNode.cloneNode(true) as HTMLElement;
@@ -266,7 +284,14 @@ export function CalendarEventBody({
       window.cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [formattedTitle, event.description, event.location, lastMod, isMobile]);
+  }, [
+    formattedTitle,
+    event.description,
+    event.location,
+    lastMod,
+    isMobile,
+    showOverlapStack,
+  ]);
 
   return (
     <div
@@ -308,51 +333,66 @@ export function CalendarEventBody({
           />
         </>
       )}
-      <div ref={eventContentRef} className={styles.eventContent}>
-        <strong
-          data-event-line="true"
-          className={clsx(styles.eventLine, styles.courseCodeText)}
-        >
-          {formattedTitle}
-          {formatSectionSuffix(event.listing.course)}
-        </strong>
-        <div
-          data-event-line="true"
-          className={clsx(
-            styles.eventLine,
-            hideFromLineIndex !== null &&
-              hideFromLineIndex <= 1 &&
-              styles.eventLineHidden,
-          )}
-        >
-          <span className={styles.courseNameText}>{event.description}</span>
-        </div>
-        <small
-          data-event-line="true"
-          className={clsx(
-            styles.eventLine,
-            styles.locationText,
-            hideFromLineIndex !== null &&
-              hideFromLineIndex <= 2 &&
-              styles.eventLineHidden,
-          )}
-        >
-          {event.location}
-        </small>
-        {lastMod && (
-          <div
-            data-event-line="true"
-            className={clsx(
-              styles.eventLine,
-              hideFromLineIndex !== null &&
-                hideFromLineIndex <= 3 &&
-                styles.eventLineHidden,
+      <div
+        ref={eventContentRef}
+        className={clsx(
+          styles.eventContent,
+          showOverlapStack && styles.eventContentStack,
+        )}
+      >
+        {showOverlapStack ? (
+          <OverlapStackRows
+            peers={stackPeers}
+            onPickStackCourse={onPickStackCourse}
+          />
+        ) : (
+          <>
+            <strong
+              data-event-line="true"
+              className={clsx(styles.eventLine, styles.courseCodeText)}
+            >
+              {formattedTitle}
+              {formatSectionSuffix(event.listing.course)}
+            </strong>
+            <div
+              data-event-line="true"
+              className={clsx(
+                styles.eventLine,
+                hideFromLineIndex !== null &&
+                  hideFromLineIndex <= 1 &&
+                  styles.eventLineHidden,
+              )}
+            >
+              <span className={styles.courseNameText}>{event.description}</span>
+            </div>
+            <small
+              data-event-line="true"
+              className={clsx(
+                styles.eventLine,
+                styles.locationText,
+                hideFromLineIndex !== null &&
+                  hideFromLineIndex <= 2 &&
+                  styles.eventLineHidden,
+              )}
+            >
+              {event.location}
+            </small>
+            {lastMod && (
+              <div
+                data-event-line="true"
+                className={clsx(
+                  styles.eventLine,
+                  hideFromLineIndex !== null &&
+                    hideFromLineIndex <= 3 &&
+                    styles.eventLineHidden,
+                )}
+              >
+                <span className={styles.lastUpdatedText}>
+                  Last updated: {new Date(lastMod).toLocaleDateString()}
+                </span>
+              </div>
             )}
-          >
-            <span className={styles.lastUpdatedText}>
-              Last updated: {new Date(lastMod).toLocaleDateString()}
-            </span>
-          </div>
+          </>
         )}
       </div>
     </div>
@@ -615,9 +655,16 @@ function WalkClassDetails({
 function CalendarEvent({
   event,
   onWalkModalInteraction,
+  stackPeers,
+  onPickStackCourse,
 }: {
   readonly event: CourseRBCEvent;
   readonly onWalkModalInteraction?: (interaction: WalkModalInteraction) => void;
+  readonly stackPeers?: CourseRBCEvent[];
+  readonly onPickStackCourse?: (
+    picked: CourseRBCEvent,
+    e: SyntheticEvent,
+  ) => void;
 }) {
   const { listing } = event;
   const isReadonlyWorksheet = useStore((state) =>
@@ -629,6 +676,8 @@ function CalendarEvent({
       <CalendarEventBody
         event={event}
         onWalkModalInteraction={onWalkModalInteraction}
+        stackPeers={stackPeers}
+        onPickStackCourse={onPickStackCourse}
       />
       {!isReadonlyWorksheet && (
         <div className={styles.eventButtons}>
@@ -652,9 +701,23 @@ function CalendarEvent({
 export function useEventStyle() {
   const hoverCourse = useStore((state) => state.hoverCourse);
   const isMobile = useStore((state) => state.isMobile);
-  // Custom styling for the calendar events
   const eventStyleGetter = useCallback(
-    (event: CourseRBCEvent) => {
+    (event: CourseRBCEvent, _start: Date, _end: Date, isSelected?: boolean) => {
+      const cluster = event.overlapCluster;
+      const isGhost = cluster && cluster.peers.length > 1 && cluster.index > 0;
+      if (isGhost) {
+        return {
+          style: {
+            opacity: 0,
+            pointerEvents: 'none' as const,
+            borderWidth: 0,
+            backgroundColor: 'transparent',
+            zIndex: 0,
+          },
+          className: 'rbc-event-stacked-ghost',
+        };
+      }
+
       const color = chroma(event.color);
       let backgroundColor = color.alpha(0.85).css();
       let borderColor = color.css();
@@ -670,16 +733,32 @@ export function useEventStyle() {
         }
       }
 
+      const stackedPrimary =
+        cluster && cluster.peers.length > 1 && cluster.index === 0;
+
       const style: React.CSSProperties = {
         backgroundColor,
         borderColor,
-        borderWidth: '2px',
+        borderWidth: stackedPrimary && isSelected ? '0' : '2px',
+        overflow: stackedPrimary ? 'hidden' : undefined,
       };
-      // Hover management is too hard on mobile and not very useful
-      if (isMobile) return { style };
+
+      if (stackedPrimary && isSelected)
+        style.boxShadow = `inset 0 0 0 2px ${borderColor}`;
+
+      if (event.walkBefore && stackedPrimary) style.overflow = 'visible';
+
+      if (isMobile) {
+        return {
+          style,
+          className: stackedPrimary ? 'rbc-event-overlap-primary' : undefined,
+        };
+      }
       if (hoverCourse && hoverCourse === event.listing.crn) style.zIndex = 2;
+      else if (stackedPrimary) style.zIndex = 3;
       return {
         style,
+        className: stackedPrimary ? 'rbc-event-overlap-primary' : undefined,
       };
     },
     [isMobile, hoverCourse],

--- a/frontend/src/components/Worksheet/CalendarEvent.tsx
+++ b/frontend/src/components/Worksheet/CalendarEvent.tsx
@@ -1,4 +1,6 @@
 import React, {
+  cloneElement,
+  isValidElement,
   useCallback,
   useEffect,
   useId,
@@ -698,6 +700,28 @@ function CalendarEvent({
   );
 }
 
+export function BigCalendarGhostFocusWrapper({
+  event,
+  children,
+}: React.PropsWithChildren<{ readonly event: CourseRBCEvent }>) {
+  const cluster = event.overlapCluster;
+  if (
+    cluster &&
+    cluster.peers.length > 1 &&
+    cluster.index > 0 &&
+    isValidElement(children)
+  ) {
+    return cloneElement(
+      children as React.ReactElement<{
+        tabIndex?: number;
+        'aria-hidden'?: boolean | 'true' | 'false';
+      }>,
+      { tabIndex: -1, 'aria-hidden': true },
+    );
+  }
+  return children;
+}
+
 export function useEventStyle() {
   const hoverCourse = useStore((state) => state.hoverCourse);
   const isMobile = useStore((state) => state.isMobile);
@@ -708,7 +732,7 @@ export function useEventStyle() {
       if (isGhost) {
         return {
           style: {
-            opacity: 0,
+            visibility: 'hidden' as const,
             pointerEvents: 'none' as const,
             borderWidth: 0,
             backgroundColor: 'transparent',

--- a/frontend/src/components/Worksheet/CalendarOverlapStack.module.css
+++ b/frontend/src/components/Worksheet/CalendarOverlapStack.module.css
@@ -1,0 +1,181 @@
+.overlapStack {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.overlapMeasure {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.overlapRow {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  min-width: 0;
+  padding: 2px 4px 2px 6px;
+  border: 0;
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  background: var(--overlap-row-bg, rgb(0 0 0 / 12%));
+  border-left: 3px solid var(--overlap-accent, var(--color-border));
+  color: var(--overlap-row-fg, var(--color-text-dark));
+  line-height: 1.2;
+}
+
+.overlapRow:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.overlapRowMain {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+  min-width: 0;
+}
+
+.overlapCode {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overlapTitle {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  font-size: 11px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.92;
+}
+
+.overlapLocation {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  margin-top: 1px;
+  font-size: 10px;
+  font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.85;
+}
+
+.overlapMore {
+  align-self: flex-start;
+  margin-top: 1px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgb(0 0 0 / 18%);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.overlapMore:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.overlapPopover {
+  max-width: min(320px, calc(100vw - 24px));
+  z-index: 1080;
+  box-shadow:
+    0 12px 28px rgb(0 0 0 / 18%),
+    0 4px 10px rgb(0 0 0 / 12%);
+}
+
+.overlapPopoverHeader {
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 8px 12px;
+}
+
+.overlapPopoverBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  max-height: min(360px, 70vh);
+  overflow-y: auto;
+}
+
+.overlapPopoverRow {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid rgb(0 0 0 / 10%);
+  border-radius: 6px;
+  border-left-width: 4px;
+  border-left-color: var(--pop-accent, var(--color-primary));
+  background: color-mix(
+    in srgb,
+    var(--pop-accent, var(--color-primary)) 14%,
+    var(--color-surface)
+  );
+  color: var(--pop-row-fg, var(--color-text-dark));
+  text-align: left;
+  cursor: pointer;
+}
+
+.overlapPopoverRow:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.overlapPopoverCode {
+  font-size: 0.88rem;
+  font-weight: 700;
+  width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.overlapPopoverTitle {
+  font-size: 0.84rem;
+  line-height: 1.25;
+  width: 100%;
+}
+
+.overlapPopoverMeta {
+  font-size: 0.78rem;
+  opacity: 0.88;
+  width: 100%;
+}
+
+:global([data-theme='dark']) .overlapMore {
+  border-color: rgb(255 255 255 / 22%);
+}
+
+:global([data-theme='dark']) .overlapPopoverRow {
+  border-color: rgb(255 255 255 / 16%);
+}

--- a/frontend/src/components/Worksheet/CalendarOverlapStack.tsx
+++ b/frontend/src/components/Worksheet/CalendarOverlapStack.tsx
@@ -1,0 +1,265 @@
+import React, {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type SyntheticEvent,
+} from 'react';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import chroma from 'chroma-js';
+import { useStore } from '../../store';
+import type { CourseRBCEvent } from '../../utilities/calendar';
+import { formatSectionSuffix } from '../../utilities/course';
+import styles from './CalendarOverlapStack.module.css';
+
+const ROW_GAP_PX = 2;
+
+function heightThroughRow(
+  measuredRows: HTMLElement[],
+  rowCount: number,
+): number {
+  if (rowCount <= 0) return 0;
+  const last = measuredRows[rowCount - 1];
+  if (!last) return Number.POSITIVE_INFINITY;
+  return last.offsetTop + last.offsetHeight;
+}
+
+function visibleRowCountThatFits(
+  slotHeightPx: number,
+  measuredRows: HTMLElement[],
+  moreButtonHeightPx: number,
+  peerCount: number,
+): number {
+  for (let shown = peerCount; shown >= 1; shown -= 1) {
+    const rowsHeight = heightThroughRow(measuredRows, shown);
+    const extraForMoreLink =
+      shown < peerCount ? ROW_GAP_PX + moreButtonHeightPx : 0;
+    const totalHeight = rowsHeight + extraForMoreLink;
+    if (totalHeight <= slotHeightPx) return shown;
+  }
+  return 1;
+}
+
+function RowButton({
+  peer,
+  isMobile,
+  onPick,
+  measure,
+}: {
+  readonly peer: CourseRBCEvent;
+  readonly isMobile: boolean;
+  readonly onPick: (picked: CourseRBCEvent, e: SyntheticEvent) => void;
+  readonly measure?: boolean;
+}) {
+  const rowBg = chroma(peer.color).alpha(0.22).css();
+  const textColor =
+    chroma.contrast(peer.color, 'white') > 2 ? '#fff' : 'rgb(20 24 35)';
+  return (
+    <button
+      type="button"
+      className={styles.overlapRow}
+      style={
+        {
+          '--overlap-row-bg': rowBg,
+          '--overlap-accent': peer.color,
+          '--overlap-row-fg': textColor,
+        } as React.CSSProperties
+      }
+      tabIndex={measure ? -1 : undefined}
+      aria-hidden={measure ? true : undefined}
+      {...(measure ? { 'data-overlap-row': '' } : {})}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        if (measure) return;
+        e.stopPropagation();
+        e.preventDefault();
+        onPick(peer, e);
+      }}
+    >
+      <span className={styles.overlapRowMain}>
+        <strong className={styles.overlapCode}>
+          {peer.title}
+          {formatSectionSuffix(peer.listing.course)}
+        </strong>
+        {!isMobile && (
+          <span className={styles.overlapTitle}>{peer.description}</span>
+        )}
+      </span>
+      {!isMobile && peer.location && (
+        <span className={styles.overlapLocation}>{peer.location}</span>
+      )}
+    </button>
+  );
+}
+
+export function OverlapStackRows({
+  peers,
+  onPickStackCourse,
+}: {
+  readonly peers: CourseRBCEvent[];
+  readonly onPickStackCourse: (
+    picked: CourseRBCEvent,
+    e: SyntheticEvent,
+  ) => void;
+}) {
+  const isMobile = useStore((state) => state.isMobile);
+  const stackRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const moreMeasureRef = useRef<HTMLButtonElement>(null);
+  const [visibleCount, setVisibleCount] = useState(() => peers.length);
+
+  useLayoutEffect(() => {
+    let rafId: number | null = null;
+
+    const updateVisibleCountFromMeasure = () => {
+      const stackEl = stackRef.current;
+      const measureEl = measureRef.current;
+      const peerCount = peers.length;
+
+      if (!stackEl || !measureEl) return;
+      if (peerCount <= 1) {
+        setVisibleCount(Math.max(1, peerCount));
+        return;
+      }
+
+      const slotHeightPx = stackEl.clientHeight;
+      if (slotHeightPx <= 0) return;
+
+      const measuredRows = [
+        ...measureEl.querySelectorAll<HTMLElement>('[data-overlap-row]'),
+      ];
+      const moreBtn = moreMeasureRef.current;
+      const moreButtonHeightPx = moreBtn?.offsetHeight ?? 22;
+
+      const next = visibleRowCountThatFits(
+        slotHeightPx,
+        measuredRows,
+        moreButtonHeightPx,
+        peerCount,
+      );
+      setVisibleCount((prev) => (prev === next ? prev : next));
+    };
+
+    const scheduleMeasureUpdate = () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateVisibleCountFromMeasure();
+      });
+    };
+
+    updateVisibleCountFromMeasure();
+
+    const stackForResize = stackRef.current;
+    if (!stackForResize || typeof ResizeObserver === 'undefined') {
+      return () => {
+        if (rafId !== null) cancelAnimationFrame(rafId);
+      };
+    }
+
+    const observer = new ResizeObserver(() => scheduleMeasureUpdate());
+    observer.observe(stackForResize);
+    return () => {
+      observer.disconnect();
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [peers, isMobile]);
+
+  const preview = peers.slice(0, visibleCount);
+  const moreCount = peers.length - preview.length;
+
+  return (
+    <div ref={stackRef} className={styles.overlapStack}>
+      <div ref={measureRef} className={styles.overlapMeasure} aria-hidden>
+        {peers.map((peer) => (
+          <RowButton
+            key={`m-${peer.listing.crn}-${peer.start.getTime()}`}
+            peer={peer}
+            isMobile={isMobile}
+            onPick={onPickStackCourse}
+            measure
+          />
+        ))}
+        <button
+          ref={moreMeasureRef}
+          type="button"
+          className={styles.overlapMore}
+          tabIndex={-1}
+        >
+          +{peers.length} more
+        </button>
+      </div>
+      {preview.map((peer) => (
+        <RowButton
+          key={`${peer.listing.crn}-${peer.start.getTime()}`}
+          peer={peer}
+          isMobile={isMobile}
+          onPick={onPickStackCourse}
+        />
+      ))}
+      {moreCount > 0 && (
+        <OverlayTrigger
+          trigger="click"
+          rootClose
+          placement="auto"
+          overlay={
+            <Popover
+              id="worksheet-overlap-cluster-popover"
+              className={styles.overlapPopover}
+            >
+              <Popover.Header as="div" className={styles.overlapPopoverHeader}>
+                Classes at this time ({peers.length})
+              </Popover.Header>
+              <Popover.Body className={styles.overlapPopoverBody}>
+                {peers.map((peer) => {
+                  const textColor =
+                    chroma.contrast(peer.color, 'white') > 2 ? '#fff' : '#111';
+                  return (
+                    <button
+                      key={`pop-${peer.listing.crn}-${peer.start.getTime()}`}
+                      type="button"
+                      className={styles.overlapPopoverRow}
+                      style={
+                        {
+                          '--pop-accent': peer.color,
+                          '--pop-row-fg': textColor,
+                        } as React.CSSProperties
+                      }
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        onPickStackCourse(peer, e);
+                      }}
+                    >
+                      <span className={styles.overlapPopoverCode}>
+                        {peer.title}
+                        {formatSectionSuffix(peer.listing.course)}
+                      </span>
+                      <span className={styles.overlapPopoverTitle}>
+                        {peer.description}
+                      </span>
+                      {peer.location && (
+                        <span className={styles.overlapPopoverMeta}>
+                          {peer.location}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </Popover.Body>
+            </Popover>
+          }
+        >
+          <button
+            type="button"
+            className={styles.overlapMore}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          >
+            +{moreCount} more
+          </button>
+        </OverlayTrigger>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -25,6 +25,9 @@ import {
   type CourseRBCEvent,
   type WalkBefore,
 } from '../../utilities/calendar';
+import stackConcurrentSlotLayout, {
+  attachOverlapClusters,
+} from '../../utilities/calendarStackLayout';
 import {
   getBuildingCodeFromLocation,
   getWalkingMinutes,
@@ -34,6 +37,12 @@ import './react-big-calendar-override.css';
 const MAX_WALK_GAP_MINUTES = 30;
 const WALK_MODAL_SELECT_SUPPRESSION_MS = 350;
 const WALK_MODAL_CLOSE_SUPPRESSION_MS = 600;
+
+const RBC_EVENT_WRAP_STYLE = {
+  display: 'flex' as const,
+  flexDirection: 'column' as const,
+  height: '100%',
+};
 
 type WorksheetCalendarProps = {
   readonly showWalkingTimes?: boolean;
@@ -254,11 +263,14 @@ function WorksheetCalendar({
   }, [parsedCourses]);
 
   const displayEvents = useMemo(() => {
-    if (!showWalkingTimes || walkBeforeByKey.size === 0) return parsedCourses;
-    return parsedCourses.map((event) => {
-      const walkBefore = walkBeforeByKey.get(eventKey(event));
-      return walkBefore ? { ...event, walkBefore } : event;
-    });
+    const withWalk =
+      showWalkingTimes && walkBeforeByKey.size > 0
+        ? parsedCourses.map((event) => {
+            const walkBefore = walkBeforeByKey.get(eventKey(event));
+            return walkBefore ? { ...event, walkBefore } : event;
+          })
+        : parsedCourses;
+    return attachOverlapClusters(withWalk);
   }, [parsedCourses, showWalkingTimes, walkBeforeByKey]);
   const suppressSelectEventUntilRef = useRef(0);
   const walkModalOpenRef = useRef(false);
@@ -290,24 +302,65 @@ function WorksheetCalendar({
     },
     [armSelectSuppression],
   );
+  const openCourseModal = useCallback(
+    (course: CourseRBCEvent) => {
+      setSearchParams((prev) => {
+        prev.set(
+          'course-modal',
+          `${course.listing.course.season_code}-${course.listing.crn}`,
+        );
+        return prev;
+      });
+    },
+    [setSearchParams],
+  );
+  const handlePickFromStack = useCallback(
+    (picked: CourseRBCEvent, clickEvent: SyntheticEvent) => {
+      clickEvent.stopPropagation();
+      if (walkModalOpenRef.current) return;
+      if (Date.now() < suppressSelectEventUntilRef.current) return;
+      setSelectedEvent(picked);
+      openCourseModal(picked);
+    },
+    [openCourseModal],
+  );
+  const calendarSelected = useMemo(() => {
+    if (!selectedEvent) return null;
+    const { overlapCluster } = selectedEvent;
+    if (!overlapCluster || overlapCluster.peers.length < 2)
+      return selectedEvent;
+    return overlapCluster.peers[0] ?? selectedEvent;
+  }, [selectedEvent]);
   const calendarComponents = useMemo(
     () => ({
-      event: ({ event }: { readonly event: CourseRBCEvent }) => (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100%',
-          }}
-        >
-          <CalendarEvent
-            event={event}
-            onWalkModalInteraction={suppressCalendarEventSelection}
-          />
-        </div>
-      ),
+      event({ event }: { readonly event: CourseRBCEvent }) {
+        const cluster = event.overlapCluster;
+        if (cluster && cluster.peers.length > 1 && cluster.index > 0)
+          return <div style={RBC_EVENT_WRAP_STYLE} aria-hidden />;
+
+        if (cluster && cluster.peers.length > 1 && cluster.index === 0) {
+          return (
+            <div style={RBC_EVENT_WRAP_STYLE}>
+              <CalendarEvent
+                event={event}
+                stackPeers={cluster.peers}
+                onPickStackCourse={handlePickFromStack}
+                onWalkModalInteraction={suppressCalendarEventSelection}
+              />
+            </div>
+          );
+        }
+        return (
+          <div style={RBC_EVENT_WRAP_STYLE}>
+            <CalendarEvent
+              event={event}
+              onWalkModalInteraction={suppressCalendarEventSelection}
+            />
+          </div>
+        );
+      },
     }),
-    [suppressCalendarEventSelection],
+    [handlePickFromStack, suppressCalendarEventSelection],
   );
   useEffect(() => {
     if (!selectedEvent) return;
@@ -355,19 +408,13 @@ function WorksheetCalendar({
         return;
       }
       setSelectedEvent(event);
-      setSearchParams((prev) => {
-        prev.set(
-          'course-modal',
-          `${event.listing.course.season_code}-${event.listing.crn}`,
-        );
-        return prev;
-      });
+      openCourseModal(event);
     },
-    [setSearchParams],
+    [openCourseModal],
   );
   return (
     <>
-      <Calendar
+      <Calendar<CourseRBCEvent>
         // Show Mon-Fri
         defaultView="work_week"
         views={['work_week']}
@@ -379,10 +426,11 @@ function WorksheetCalendar({
         localizer={localizer}
         toolbar={false}
         showCurrentTimeIndicator
-        selected={selectedEvent}
+        selected={calendarSelected}
         onSelectEvent={handleSelectEvent}
         components={calendarComponents}
         eventPropGetter={eventStyleGetter}
+        dayLayoutAlgorithm={stackConcurrentSlotLayout}
         tooltipAccessor={undefined}
       />
       <ColorPickerModal onClose={() => setOpenColorPickerEvent(null)} />

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -11,6 +11,7 @@ import { Calendar } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useShallow } from 'zustand/react/shallow';
 import CalendarEvent, {
+  BigCalendarGhostFocusWrapper,
   type WalkModalInteraction,
   useEventStyle,
 } from './CalendarEvent';
@@ -43,6 +44,17 @@ const RBC_EVENT_WRAP_STYLE = {
   flexDirection: 'column' as const,
   height: '100%',
 };
+
+function promoteWalkBeforeToStackedPrimaries(events: CourseRBCEvent[]) {
+  for (const e of events) {
+    const cluster = e.overlapCluster;
+    if (!cluster || cluster.peers.length < 2) continue;
+    const [primary] = cluster.peers;
+    if (!primary || primary.walkBefore) continue;
+    const donor = cluster.peers.find((p) => p.walkBefore);
+    if (donor?.walkBefore) primary.walkBefore = donor.walkBefore;
+  }
+}
 
 type WorksheetCalendarProps = {
   readonly showWalkingTimes?: boolean;
@@ -270,7 +282,9 @@ function WorksheetCalendar({
             return walkBefore ? { ...event, walkBefore } : event;
           })
         : parsedCourses;
-    return attachOverlapClusters(withWalk);
+    const clustered = attachOverlapClusters(withWalk);
+    promoteWalkBeforeToStackedPrimaries(clustered);
+    return clustered;
   }, [parsedCourses, showWalkingTimes, walkBeforeByKey]);
   const suppressSelectEventUntilRef = useRef(0);
   const walkModalOpenRef = useRef(false);
@@ -333,6 +347,7 @@ function WorksheetCalendar({
   }, [selectedEvent]);
   const calendarComponents = useMemo(
     () => ({
+      eventWrapper: BigCalendarGhostFocusWrapper,
       event({ event }: { readonly event: CourseRBCEvent }) {
         const cluster = event.overlapCluster;
         if (cluster && cluster.peers.length > 1 && cluster.index > 0)

--- a/frontend/src/components/Worksheet/WorksheetItemActionsButton.tsx
+++ b/frontend/src/components/Worksheet/WorksheetItemActionsButton.tsx
@@ -15,7 +15,11 @@ import chroma from 'chroma-js';
 import { Calendar } from 'react-big-calendar';
 import { HexColorPicker } from 'react-colorful';
 import { useShallow } from 'zustand/react/shallow';
-import { CalendarEventBody, useEventStyle } from './CalendarEvent';
+import {
+  BigCalendarGhostFocusWrapper,
+  CalendarEventBody,
+  useEventStyle,
+} from './CalendarEvent';
 import { updateWorksheetCourses } from '../../queries/api';
 import { useWorksheetNumberOptions } from '../../slices/WorksheetSlice';
 import { useStore } from '../../store';
@@ -365,7 +369,10 @@ function Preview({
         max={end}
         localizer={localizer}
         toolbar={false}
-        components={{ event: CalendarEventBody }}
+        components={{
+          event: CalendarEventBody,
+          eventWrapper: BigCalendarGhostFocusWrapper,
+        }}
         eventPropGetter={eventStyleGetter}
         tooltipAccessor={undefined}
         onNavigate={() => {}}

--- a/frontend/src/components/Worksheet/react-big-calendar-override.css
+++ b/frontend/src/components/Worksheet/react-big-calendar-override.css
@@ -88,6 +88,16 @@
   z-index: 2;
 }
 
+.rbc-day-slot .rbc-event:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.rbc-day-slot .rbc-event.rbc-event-overlap-primary .rbc-event-content {
+  overflow: hidden;
+  word-break: normal;
+}
+
 .rbc-event-label {
   display: none !important;
 }

--- a/frontend/src/utilities/calendar.ts
+++ b/frontend/src/utilities/calendar.ts
@@ -198,6 +198,12 @@ function toRBCEvent({
 
 type GCalEvent = gapi.client.calendar.EventInput;
 type ICSEvent = string;
+export type CourseOverlapCluster = {
+  readonly clusterId: string;
+  readonly peers: CourseRBCEvent[];
+  readonly index: number;
+};
+
 export type CourseRBCEvent = {
   kind: 'course';
   title: string;
@@ -208,6 +214,7 @@ export type CourseRBCEvent = {
   color: string;
   location: string;
   walkBefore?: WalkBefore;
+  overlapCluster?: CourseOverlapCluster;
 };
 
 export type WalkClassSummary = {

--- a/frontend/src/utilities/calendarStackLayout.ts
+++ b/frontend/src/utilities/calendarStackLayout.ts
@@ -14,52 +14,109 @@ type NumericLayoutStyle = {
 
 type StyledRow = { event: CourseRBCEvent; style: NumericLayoutStyle };
 
+function intervalsOverlap(a: CourseRBCEvent, b: CourseRBCEvent): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
 export function attachOverlapClusters(
   events: CourseRBCEvent[],
 ): CourseRBCEvent[] {
   const copies = events.map((e) => ({ ...e }));
-  const bySlot = new Map<string, CourseRBCEvent[]>();
+
+  const byDay = new Map<number, CourseRBCEvent[]>();
   for (const e of copies) {
-    const slotKey = `${e.start.getTime()}_${e.end.getTime()}`;
-    const group = bySlot.get(slotKey);
-    if (group) group.push(e);
-    else bySlot.set(slotKey, [e]);
+    const day = e.start.getDay();
+    const list = byDay.get(day) ?? [];
+    list.push(e);
+    byDay.set(day, list);
   }
-  for (const group of bySlot.values()) {
-    if (group.length < 2) continue;
-    const sorted = [...group].sort((a, b) =>
-      String(a.listing.crn).localeCompare(String(b.listing.crn), undefined, {
-        numeric: true,
-      }),
+
+  for (const dayEvents of byDay.values()) {
+    if (dayEvents.length < 2) continue;
+
+    const sorted = [...dayEvents].sort(
+      (a, b) => a.start.getTime() - b.start.getTime(),
     );
-    const clusterId = `${sorted[0]!.start.getTime()}_${sorted[0]!.end.getTime()}`;
-    for (let i = 0; i < sorted.length; i++) {
-      sorted[i]!.overlapCluster = {
-        clusterId,
-        peers: sorted,
-        index: i,
-      };
+    const visited = new Set<number>();
+
+    for (let i = 0; i < sorted.length; i += 1) {
+      if (visited.has(i)) continue;
+
+      const component: CourseRBCEvent[] = [];
+      const stack: number[] = [i];
+
+      while (stack.length > 0) {
+        const idx = stack.pop()!;
+        if (visited.has(idx)) continue;
+        visited.add(idx);
+        const ev = sorted[idx]!;
+        component.push(ev);
+        for (let j = 0; j < sorted.length; j += 1) {
+          if (visited.has(j)) continue;
+          if (intervalsOverlap(ev, sorted[j]!)) stack.push(j);
+        }
+      }
+
+      if (component.length < 2) continue;
+
+      const ordered = [...component].sort((a, b) =>
+        String(a.listing.crn).localeCompare(String(b.listing.crn), undefined, {
+          numeric: true,
+        }),
+      );
+      const clusterId = ordered
+        .map(
+          (e) =>
+            `${String(e.listing.crn)}_${String(e.start.getTime())}_${String(e.end.getTime())}`,
+        )
+        .join('|');
+
+      for (let k = 0; k < ordered.length; k += 1) {
+        ordered[k]!.overlapCluster = {
+          clusterId,
+          peers: ordered,
+          index: k,
+        };
+      }
     }
   }
+
   return copies;
 }
 
 const stackConcurrentSlotLayout: DayLayoutFunction<CourseRBCEvent> = (args) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- RBC internal module is untyped
   const styled = overlapLayoutRaw(args) as StyledRow[];
-  const byBand = new Map<string, StyledRow[]>();
+
+  const byClusterId = new Map<string, StyledRow[]>();
   for (const item of styled) {
-    const { top, height } = item.style;
-    const key = `${String(top)}|${String(height)}`;
-    const group = byBand.get(key);
-    if (group) group.push(item);
-    else byBand.set(key, [item]);
+    const cluster = item.event.overlapCluster;
+    if (!cluster || cluster.peers.length < 2) continue;
+    const list = byClusterId.get(cluster.clusterId) ?? [];
+    list.push(item);
+    byClusterId.set(cluster.clusterId, list);
   }
-  for (const group of byBand.values()) {
+
+  for (const group of byClusterId.values()) {
     if (group.length < 2) continue;
-    for (const item of group)
-      Object.assign(item.style, { width: 100, xOffset: 0 });
+    let minTop = Number.POSITIVE_INFINITY;
+    let maxBottom = Number.NEGATIVE_INFINITY;
+    for (const item of group) {
+      const { top, height } = item.style;
+      minTop = Math.min(minTop, top);
+      maxBottom = Math.max(maxBottom, top + height);
+    }
+    const unionHeight = maxBottom - minTop;
+    for (const item of group) {
+      Object.assign(item.style, {
+        top: minTop,
+        height: unionHeight,
+        width: 100,
+        xOffset: 0,
+      });
+    }
   }
+
   return styled as { event: CourseRBCEvent; style: CSSProperties }[];
 };
 

--- a/frontend/src/utilities/calendarStackLayout.ts
+++ b/frontend/src/utilities/calendarStackLayout.ts
@@ -1,0 +1,66 @@
+import type { CSSProperties } from 'react';
+import type { DayLayoutFunction } from 'react-big-calendar';
+
+// @ts-expect-error -- RBC has no types for lib/utils/layout-algorithms/overlap.js
+import overlapLayoutRaw from 'react-big-calendar/lib/utils/layout-algorithms/overlap.js';
+import type { CourseRBCEvent } from './calendar';
+
+type NumericLayoutStyle = {
+  top: number;
+  height: number;
+  width: number;
+  xOffset: number;
+};
+
+type StyledRow = { event: CourseRBCEvent; style: NumericLayoutStyle };
+
+export function attachOverlapClusters(
+  events: CourseRBCEvent[],
+): CourseRBCEvent[] {
+  const copies = events.map((e) => ({ ...e }));
+  const bySlot = new Map<string, CourseRBCEvent[]>();
+  for (const e of copies) {
+    const slotKey = `${e.start.getTime()}_${e.end.getTime()}`;
+    const group = bySlot.get(slotKey);
+    if (group) group.push(e);
+    else bySlot.set(slotKey, [e]);
+  }
+  for (const group of bySlot.values()) {
+    if (group.length < 2) continue;
+    const sorted = [...group].sort((a, b) =>
+      String(a.listing.crn).localeCompare(String(b.listing.crn), undefined, {
+        numeric: true,
+      }),
+    );
+    const clusterId = `${sorted[0]!.start.getTime()}_${sorted[0]!.end.getTime()}`;
+    for (let i = 0; i < sorted.length; i++) {
+      sorted[i]!.overlapCluster = {
+        clusterId,
+        peers: sorted,
+        index: i,
+      };
+    }
+  }
+  return copies;
+}
+
+const stackConcurrentSlotLayout: DayLayoutFunction<CourseRBCEvent> = (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- RBC internal module is untyped
+  const styled = overlapLayoutRaw(args) as StyledRow[];
+  const byBand = new Map<string, StyledRow[]>();
+  for (const item of styled) {
+    const { top, height } = item.style;
+    const key = `${String(top)}|${String(height)}`;
+    const group = byBand.get(key);
+    if (group) group.push(item);
+    else byBand.set(key, [item]);
+  }
+  for (const group of byBand.values()) {
+    if (group.length < 2) continue;
+    for (const item of group)
+      Object.assign(item.style, { width: 100, xOffset: 0 });
+  }
+  return styled as { event: CourseRBCEvent; style: CSSProperties }[];
+};
+
+export default stackConcurrentSlotLayout;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "pnpm": "please-use-bun"
   },
   "overrides": {
-    "eslint-plugin-react-hooks": "Please see https://github.com/facebook/react/issues/35045 (this is a comment—remove once it's resolved)",
     "eslint-plugin-react-hooks": "7.0.0"
   },
   "patchedDependencies": {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have searched for potential duplicate pull requests.
- [x] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary
Playing around with new calendar view for concurrent courses. Pictured below: multiple courses not overflowing (left), multiple courses overflowing (right)

<img width="216" height="443" alt="Screenshot 2026-04-08 at 6 27 23 PM" src="https://github.com/user-attachments/assets/3094131b-5f34-4223-97e9-295c7a996eff" />
<img width="215" height="442" alt="Screenshot 2026-04-08 at 6 27 14 PM" src="https://github.com/user-attachments/assets/56840596-e738-4c3a-9d34-443181e5c03c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overlapping calendar events now display as a stacked list with per-item selection and a “+N more” popover to view all conflicting courses; primary item is emphasized for easier selection.

* **Style**
  * Refined spacing, truncation, and keyboard focus outlines for events and overlap controls; stacked items render clearer visuals and improved focus behavior for accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->