### PR TITLE
fix: remove course/prof toggle from overview ratings

### DIFF
--- a/frontend/src/components/CourseModal/OverviewPanel/OverviewRatings.module.css
+++ b/frontend/src/components/CourseModal/OverviewPanel/OverviewRatings.module.css
@@ -1,48 +1,3 @@
-/* Match worksheet NavbarWorksheetSearch ToggleButtonGroup styling */
-.filterToggleGroup {
-  width: 100%;
-  max-width: 320px;
-}
-
-.filterToggleButton {
-  --bs-btn-active-bg: var(--color-primary);
-  --bs-btn-active-border-color: var(--color-primary);
-
-  flex: 1 1 0;
-  min-width: 0;
-  font-size: 14px;
-  font-weight: 500;
-  background-color: var(--color-surface);
-  color: var(--color-text);
-  border: var(--color-icon) 2px solid;
-  padding: 0.25rem 0.35rem;
-  transition:
-    border-color var(--trans-dur),
-    background-color var(--trans-dur),
-    color var(--trans-dur);
-}
-
-.filterToggleButton:hover {
-  background-color: var(--color-surface-hover);
-  color: var(--color-text);
-  border: var(--color-primary-hover) 2px solid;
-}
-
-.filterToggleButton:active {
-  background-color: var(--color-surface-active) !important;
-  color: var(--color-text) !important;
-}
-
-.filterToggleButton:focus {
-  box-shadow: none !important;
-}
-
-.filterToggleButton:global(.active) {
-  background-color: var(--color-primary) !important;
-  border-color: var(--color-primary) !important;
-  color: #fff !important;
-}
-
 .aggregateContainer {
   margin: 0 0 0.75rem;
   padding: 0.75rem;
@@ -100,10 +55,4 @@
   padding: 3px 10px;
   line-height: 1.5;
   min-height: 1.5rem;
-}
-
-.filterContainer {
-  display: flex;
-  margin: auto;
-  justify-content: center;
 }

--- a/frontend/src/components/CourseModal/OverviewPanel/OverviewRatings.tsx
+++ b/frontend/src/components/CourseModal/OverviewPanel/OverviewRatings.tsx
@@ -1,14 +1,7 @@
-import React, { useState, type ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import clsx from 'clsx';
-import {
-  Form,
-  Badge,
-  OverlayTrigger,
-  Tooltip,
-  ToggleButton,
-  ToggleButtonGroup,
-} from 'react-bootstrap';
+import { Form, Badge, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { AiOutlineStar } from 'react-icons/ai';
 import { BiBookOpen } from 'react-icons/bi';
 import { IoPersonOutline } from 'react-icons/io5';
@@ -34,14 +27,7 @@ import type { ModalNavigationFunction } from '../CourseModal';
 
 import styles from './OverviewRatings.module.css';
 
-type Filter = 'course' | 'professor';
-
 type RelatedCourseInfo = CourseModalOverviewDataQuery['sameCourse'][number];
-
-type CourseProfOption = {
-  readonly displayName: string;
-  readonly value: Filter;
-};
 
 function createProfSummary(
   courseProfessors: RelatedCourseInfo['course_professors'],
@@ -100,38 +86,6 @@ function createProfSummary(
     </>
   );
   return { key: names.join(' • '), links };
-}
-
-function CourseProfFilter({
-  options,
-  filter,
-  onChange,
-}: {
-  readonly options: readonly CourseProfOption[];
-  readonly filter: Filter;
-  readonly onChange: (value: Filter) => void;
-}) {
-  return (
-    <ToggleButtonGroup
-      type="radio"
-      name="course-modal-ratings-view"
-      value={filter}
-      onChange={(val) => onChange(val as Filter)}
-      className={clsx(styles.filterToggleGroup, 'mb-2')}
-      aria-label="Evaluation ratings view"
-    >
-      {options.map((opt) => (
-        <ToggleButton
-          key={opt.value}
-          id={`overview-ratings-${opt.value}`}
-          className={styles.filterToggleButton}
-          value={opt.value}
-        >
-          {opt.displayName}
-        </ToggleButton>
-      ))}
-    </ToggleButtonGroup>
-  );
 }
 
 function AggregateRating({
@@ -221,12 +175,6 @@ function OverviewRatings({
         b.season_code.localeCompare(a.season_code, 'en-US') ||
         parseInt(a.section, 10) - parseInt(b.section, 10),
     );
-
-  const options: readonly CourseProfOption[] = [
-    { displayName: `Course (${sameCourseNormalized.length})`, value: 'course' },
-    { displayName: 'Prof', value: 'professor' },
-  ];
-  const [filter, setFilter] = useState<Filter>('course');
 
   const { groupSameProf, togglePref } = useStore(
     useShallow((state) => ({
@@ -318,45 +266,7 @@ function OverviewRatings({
           />
         </div>
       </div>
-      <div className={styles.filterContainer}>
-        <CourseProfFilter
-          options={options}
-          filter={filter}
-          onChange={setFilter}
-        />
-      </div>
-      {filter === 'professor' ? (
-        <div className="alert alert-info m-3">
-          <p>
-            We've moved! To view course offerings by each professor, click on
-            their name on the left, or select from the list below.
-          </p>
-          <ul>
-            {listing.course.course_professors.map((prof) => (
-              <li key={prof.professor.professor_id}>
-                <Link
-                  to={createProfModalLink(
-                    prof.professor.professor_id,
-                    searchParams,
-                  )}
-                  onClick={() => {
-                    navigate(
-                      'push',
-                      {
-                        type: 'professor',
-                        data: prof.professor.professor_id,
-                      },
-                      searchParams,
-                    );
-                  }}
-                >
-                  {prof.professor.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : sameCourseNormalized.length !== 0 ? (
+      {sameCourseNormalized.length !== 0 ? (
         <>
           <Form.Check type="switch" className="mb-3">
             <Form.Check.Input


### PR DESCRIPTION
reverting some of the changes that were introduced in #1879 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the course/professor filter toggle from the ratings overview panel. The ratings section now displays in a single, simplified view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->