### PR TITLE
feat: improve search relevance with aliases and typo tolerance

### DIFF
--- a/frontend/src/search/SearchBootstrap.tsx
+++ b/frontend/src/search/SearchBootstrap.tsx
@@ -15,7 +15,7 @@ import {
   emptyFilters,
   SEARCH_FILTER_KEYS,
 } from './searchConstants';
-import { matchesSearchText } from './searchTextMatch';
+import { searchMatchQuality } from './searchTextMatch';
 import type {
   BooleanAttributes,
   FilterHandle,
@@ -425,6 +425,7 @@ export function SearchBootstrap({
         return [...data.values()];
       });
 
+      const qualityMap = new Map<CatalogListing, number>();
       const filtered = listings.filter((listing: CatalogListing) => {
         // For empty bounds, don't apply filters at all to include no ratings
         if (overallBounds.isNonEmpty) {
@@ -622,16 +623,19 @@ export function SearchBootstrap({
 
         if (quistPredicate) return quistPredicate(listing);
         // Handle search text. Each token must match something.
-        return matchesSearchText(listing, processedSearchTextParam, {
+        const quality = searchMatchQuality(listing, processedSearchTextParam, {
           searchDescription: searchDescription.value,
         });
+        if (quality > 0) qualityMap.set(listing, quality);
+        return quality > 0;
       });
-      // Apply sorting order.
+      // Apply sorting order, with match quality as primary when searching.
       setSearchData(
         sortCourses(
           filtered,
           { key: selectSortBy.value.value, type: sortOrder.value },
           numFriends,
+          qualityMap.size > 0 ? qualityMap : undefined,
         ),
       );
     },

--- a/frontend/src/search/searchTextMatch.test.ts
+++ b/frontend/src/search/searchTextMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { matchesSearchText } from './searchTextMatch';
+import { matchesSearchText, searchMatchQuality } from './searchTextMatch';
 import type { CatalogListing } from '../queries/api';
 import type { Crn } from '../queries/graphql-types';
 
@@ -237,5 +237,364 @@ describe('matchesSearchText — subject full-name matching', () => {
       title: 'Data Structures',
     });
     expect(matchesSearchText(listing, ['biology'], defaultOpts)).toBe(false);
+  });
+});
+
+// Fuzzy (typo tolerance) matching
+
+describe('matchesSearchText — typo tolerance', () => {
+  it('"algorthms" fuzzy-matches title word "Algorithms"', () => {
+    const listing = makeListing({ title: 'Design and Analysis of Algorithms' });
+    expect(matchesSearchText(listing, ['algorthms'], defaultOpts)).toBe(true);
+  });
+
+  it('"intrduction" fuzzy-matches title word "Introduction"', () => {
+    const listing = makeListing({
+      title: 'Introduction to Computer Science',
+    });
+    expect(matchesSearchText(listing, ['intrduction'], defaultOpts)).toBe(true);
+  });
+
+  it('"calclus" fuzzy-matches title word "Calculus"', () => {
+    const listing = makeListing({ title: 'Calculus of Functions' });
+    expect(matchesSearchText(listing, ['calclus'], defaultOpts)).toBe(true);
+  });
+
+  it('"psycology" fuzzy-matches subject name "Psychology"', () => {
+    const listing = makeListing({
+      subject: 'PSYC',
+      title: 'Research Methods',
+    });
+    expect(matchesSearchText(listing, ['psycology'], defaultOpts)).toBe(true);
+  });
+
+  it('"shakspeare" fuzzy-matches professor name "Shakespeare"', () => {
+    const listing = makeListing({
+      title: 'English Literature',
+      professors: ['William Shakespeare'],
+    });
+    expect(matchesSearchText(listing, ['shakspeare'], defaultOpts)).toBe(true);
+  });
+
+  it('short tokens (<=2 chars) do not fuzzy-match', () => {
+    const listing = makeListing({ subject: 'MATH', title: 'Data Structures' });
+    // "ds" should not fuzzy-match "Data" or "Structures"
+    expect(matchesSearchText(listing, ['ds'], defaultOpts)).toBe(false);
+  });
+
+  it('fuzzy match respects multi-token AND', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Introduction to Algorithms',
+    });
+    // Both tokens must match: "cpsc" exact + "algorthms" fuzzy
+    expect(matchesSearchText(listing, ['cpsc', 'algorthms'], defaultOpts)).toBe(
+      true,
+    );
+    // "algorthms" fuzzy matches but "xyz" matches nothing
+    expect(matchesSearchText(listing, ['algorthms', 'xyz'], defaultOpts)).toBe(
+      false,
+    );
+  });
+
+  it('does not fuzzy-match subject codes', () => {
+    // "cpss" is 1 edit from "cpsc" but subject codes are exact-only
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Data Structures',
+    });
+    expect(matchesSearchText(listing, ['cpss'], defaultOpts)).toBe(false);
+  });
+
+  it('does not fuzzy-match course numbers', () => {
+    const listing = makeListing({
+      number: '201',
+      title: 'Data Structures',
+    });
+    // "202" is 1 edit from "201" but numbers are exact-only
+    expect(matchesSearchText(listing, ['202'], defaultOpts)).toBe(false);
+  });
+
+  it('regression: exact queries still work unchanged', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      number: '201',
+      title: 'Introduction to Computer Science',
+      professors: ['Dana Angluin'],
+    });
+    expect(matchesSearchText(listing, ['cpsc'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['201'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['intro'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['cpsc', '201'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['angluin'], defaultOpts)).toBe(true);
+  });
+
+  it('rejects typos that exceed the max edit distance', () => {
+    const listing = makeListing({ title: 'Algorithms' });
+    // "algrthms" has 2 edits from "algorithms" — still within maxDist=2
+    expect(matchesSearchText(listing, ['algrthms'], defaultOpts)).toBe(true);
+    // "algrtms" has 3 edits — exceeds maxDist=2
+    expect(matchesSearchText(listing, ['algrtms'], defaultOpts)).toBe(false);
+  });
+
+  it('handles adjacent transpositions better than plain Levenshtein', () => {
+    const listing = makeListing({ title: 'Algorithms' });
+    // "algorihtms" — one transposition (th→ht), OSA distance 1
+    expect(matchesSearchText(listing, ['algorihtms'], defaultOpts)).toBe(true);
+    // "algorihtm" — transposition + missing 's', OSA distance 2
+    // (would be Levenshtein 3 and fail without transposition support)
+    expect(matchesSearchText(listing, ['algorihtm'], defaultOpts)).toBe(true);
+  });
+
+  it('"alogirhtms" is still too distant (3 transpositions)', () => {
+    const listing = makeListing({ title: 'Algorithms' });
+    // 3 separate transpositions → OSA distance 3 > maxDist 2
+    expect(matchesSearchText(listing, ['alogirhtms'], defaultOpts)).toBe(false);
+  });
+
+  it('transposition works for short tokens (length 3–4, maxDist 1)', () => {
+    const listing = makeListing({ title: 'The Art of Data' });
+    // "teh" → "the": one transposition, OSA distance 1
+    expect(matchesSearchText(listing, ['teh'], defaultOpts)).toBe(true);
+    // "daat" → "data": one transposition, OSA distance 1
+    expect(matchesSearchText(listing, ['daat'], defaultOpts)).toBe(true);
+  });
+});
+
+// Alias expansion
+
+describe('matchesSearchText — alias expansion', () => {
+  it('"cs" matches CPSC via alias', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Data Structures',
+    });
+    expect(matchesSearchText(listing, ['cs'], defaultOpts)).toBe(true);
+  });
+
+  it('"cs" with course number matches CPSC course', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      number: '201',
+      title: 'Introduction to Computer Science',
+    });
+    expect(matchesSearchText(listing, ['cs', '201'], defaultOpts)).toBe(true);
+  });
+
+  it('"cs" still matches subject codes starting with CS', () => {
+    const listing = makeListing({
+      subject: 'CSEC',
+      title: 'Computer Science and Economics',
+    });
+    expect(matchesSearchText(listing, ['cs'], defaultOpts)).toBe(true);
+  });
+
+  it('"orgo" matches courses with "Organic" in the title', () => {
+    const listing = makeListing({
+      subject: 'CHEM',
+      title: 'Organic Chemistry',
+    });
+    expect(matchesSearchText(listing, ['orgo'], defaultOpts)).toBe(true);
+  });
+
+  it('"orgo" does not match unrelated chemistry courses', () => {
+    const listing = makeListing({
+      subject: 'CHEM',
+      title: 'Physical Chemistry',
+    });
+    expect(matchesSearchText(listing, ['orgo'], defaultOpts)).toBe(false);
+  });
+
+  it('"polisci" matches PLSC via alias', () => {
+    const listing = makeListing({
+      subject: 'PLSC',
+      title: 'Introduction to Political Science',
+    });
+    expect(matchesSearchText(listing, ['polisci'], defaultOpts)).toBe(true);
+  });
+
+  it('"psych" already matches PSYC without alias (via subject name)', () => {
+    const listing = makeListing({
+      subject: 'PSYC',
+      title: 'Research Methods',
+    });
+    expect(matchesSearchText(listing, ['psych'], defaultOpts)).toBe(true);
+  });
+
+  it('"econ" already matches ECON without alias (via subject code prefix)', () => {
+    const listing = makeListing({
+      subject: 'ECON',
+      title: 'Intermediate Microeconomics',
+    });
+    expect(matchesSearchText(listing, ['econ'], defaultOpts)).toBe(true);
+  });
+
+  it('"ml" has no alias and does not match "Machine Learning"', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Machine Learning',
+    });
+    expect(matchesSearchText(listing, ['ml'], defaultOpts)).toBe(false);
+  });
+
+  it('"ai" has no alias and does not match "Artificial Intelligence"', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Artificial Intelligence',
+    });
+    expect(matchesSearchText(listing, ['ai'], defaultOpts)).toBe(false);
+  });
+
+  it('alias expansion preserves multi-token AND', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      number: '365',
+      title: 'Design and Analysis of Algorithms',
+    });
+    expect(matchesSearchText(listing, ['cs', '365'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['cs', '999'], defaultOpts)).toBe(false);
+  });
+});
+
+// Match quality tiers
+
+describe('searchMatchQuality — quality tiers', () => {
+  it('subject code prefix → quality 4', () => {
+    const listing = makeListing({ subject: 'CPSC', title: 'Data Structures' });
+    expect(searchMatchQuality(listing, ['cpsc'], defaultOpts)).toBe(4);
+  });
+
+  it('course number prefix → quality 4', () => {
+    const listing = makeListing({ number: '201', title: 'Data Structures' });
+    expect(searchMatchQuality(listing, ['201'], defaultOpts)).toBe(4);
+  });
+
+  it('building code prefix → quality 4', () => {
+    const listing = makeListing({
+      title: 'Intro',
+      buildingCodes: ['WTS'],
+    });
+    expect(searchMatchQuality(listing, ['wts'], defaultOpts)).toBe(4);
+  });
+
+  it('subject full name → quality 3', () => {
+    const listing = makeListing({
+      subject: 'PSYC',
+      title: 'Research Methods',
+    });
+    expect(searchMatchQuality(listing, ['psychology'], defaultOpts)).toBe(3);
+  });
+
+  it('alias expansion to subject code → quality 4', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Data Structures',
+    });
+    // Cs → cpsc → subject prefix match → same tier as direct prefix
+    expect(searchMatchQuality(listing, ['cs'], defaultOpts)).toBe(4);
+  });
+
+  it('alias expansion to title substring → quality 2', () => {
+    const listing = makeListing({
+      subject: 'CHEM',
+      title: 'Organic Chemistry',
+    });
+    // Orgo → organic → title substring match
+    expect(searchMatchQuality(listing, ['orgo'], defaultOpts)).toBe(2);
+  });
+
+  it('title substring → quality 2', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Introduction to Computer Science',
+    });
+    expect(searchMatchQuality(listing, ['introduction'], defaultOpts)).toBe(2);
+  });
+
+  it('professor name → quality 2', () => {
+    const listing = makeListing({
+      title: 'Intro',
+      professors: ['Dana Angluin'],
+    });
+    expect(searchMatchQuality(listing, ['angluin'], defaultOpts)).toBe(2);
+  });
+
+  it('fuzzy match → quality 1', () => {
+    const listing = makeListing({ title: 'Algorithms' });
+    expect(searchMatchQuality(listing, ['algorthms'], defaultOpts)).toBe(1);
+  });
+
+  it('no match → quality 0', () => {
+    const listing = makeListing({ title: 'Data Structures' });
+    expect(searchMatchQuality(listing, ['quantum'], defaultOpts)).toBe(0);
+  });
+
+  it('empty tokens → quality 4 (match everything)', () => {
+    const listing = makeListing({ title: 'Anything' });
+    expect(searchMatchQuality(listing, [], defaultOpts)).toBe(4);
+  });
+});
+
+describe('searchMatchQuality — multi-token and ranking', () => {
+  it('multi-token quality is minimum across tokens', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      title: 'Introduction to Algorithms',
+    });
+    // "cpsc" = 4 (subject prefix), "algorithms" = 2 (title substring)
+    expect(
+      searchMatchQuality(listing, ['cpsc', 'algorithms'], defaultOpts),
+    ).toBe(2);
+  });
+
+  it('alias-expanded subject match ranks equal to direct prefix', () => {
+    const cpsc = makeListing({ subject: 'CPSC', title: 'Data Structures' });
+    const csec = makeListing({
+      subject: 'CSEC',
+      title: 'CS and Economics',
+    });
+    // Both are quality 4: CSEC via direct prefix, CPSC via alias → subject prefix
+    expect(searchMatchQuality(csec, ['cs'], defaultOpts)).toBe(4);
+    expect(searchMatchQuality(cpsc, ['cs'], defaultOpts)).toBe(4);
+  });
+
+  it('exact title match outranks fuzzy match', () => {
+    const listing = makeListing({ title: 'Algorithms' });
+    const exactQ = searchMatchQuality(listing, ['algorithms'], defaultOpts);
+    const fuzzyQ = searchMatchQuality(listing, ['algorthms'], defaultOpts);
+    expect(exactQ).toBeGreaterThan(fuzzyQ);
+  });
+
+  it('subject name match outranks title substring', () => {
+    // "economics" matches ECON via subject name (quality 3)
+    const econSubject = makeListing({
+      subject: 'ECON',
+      title: 'Intermediate Microeconomics',
+    });
+    // "economics" appears in "microeconomics" title substring (quality 2)
+    const otherTitle = makeListing({
+      subject: 'HIST',
+      title: 'History of Economics',
+    });
+    expect(
+      searchMatchQuality(econSubject, ['economics'], defaultOpts),
+    ).toBeGreaterThan(
+      searchMatchQuality(otherTitle, ['economics'], defaultOpts),
+    );
+  });
+
+  it('existing boolean matching is unchanged', () => {
+    const listing = makeListing({
+      subject: 'CPSC',
+      number: '201',
+      title: 'Introduction to Computer Science',
+      professors: ['Dana Angluin'],
+    });
+    expect(matchesSearchText(listing, ['cpsc'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['201'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['intro'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['cpsc', '201'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['angluin'], defaultOpts)).toBe(true);
+    expect(matchesSearchText(listing, ['quantum'], defaultOpts)).toBe(false);
   });
 });

--- a/frontend/src/search/searchTextMatch.ts
+++ b/frontend/src/search/searchTextMatch.ts
@@ -49,9 +49,9 @@ function fuzzyMatchesAnyWord(
   text: string,
   maxDist: number,
 ): boolean {
-  for (const word of text.toLowerCase().split(/\s+/u)) 
+  for (const word of text.toLowerCase().split(/\s+/u))
     if (word && editDistance(token, word, maxDist) <= maxDist) return true;
-  
+
   return false;
 }
 

--- a/frontend/src/search/searchTextMatch.ts
+++ b/frontend/src/search/searchTextMatch.ts
@@ -2,6 +2,164 @@ import type { CatalogListing } from '../queries/api';
 import { subjects } from '../utilities/constants';
 
 /**
+ * Optimal String Alignment distance (transposition-aware edit distance).
+ * Like Levenshtein but adjacent transpositions cost 1 instead of 2.
+ */
+function editDistance(a: string, b: string, maxDist: number): number {
+  const m = a.length;
+  const n = b.length;
+  if (Math.abs(m - n) > maxDist) return maxDist + 1;
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  // Three rows for transposition lookback: pp (i-2), p (i-1), c (i)
+  let pp: number[] = new Array<number>(n + 1);
+  let p: number[] = new Array<number>(n + 1);
+  let c: number[] = new Array<number>(n + 1);
+
+  for (let j = 0; j <= n; j++) p[j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    c[0] = i;
+    for (let j = 1; j <= n; j++) {
+      c[j] =
+        a.charCodeAt(i - 1) === b.charCodeAt(j - 1)
+          ? p[j - 1]!
+          : 1 + Math.min(p[j - 1]!, p[j]!, c[j - 1]!);
+      if (
+        i > 1 &&
+        j > 1 &&
+        a.charCodeAt(i - 1) === b.charCodeAt(j - 2) &&
+        a.charCodeAt(i - 2) === b.charCodeAt(j - 1)
+      )
+        c[j] = Math.min(c[j]!, pp[j - 2]! + 1);
+    }
+    const tmp = pp;
+    pp = p;
+    p = c;
+    c = tmp;
+  }
+
+  return p[n]!;
+}
+
+/** True if token fuzzy-matches any whitespace-delimited word in text. */
+function fuzzyMatchesAnyWord(
+  token: string,
+  text: string,
+  maxDist: number,
+): boolean {
+  for (const word of text.toLowerCase().split(/\s+/u)) 
+    if (word && editDistance(token, word, maxDist) <= maxDist) return true;
+  
+  return false;
+}
+
+// Common student shorthand → tokens to also try
+const searchAliases: { [key: string]: readonly string[] } = {
+  cs: ['cpsc'],
+  orgo: ['organic'],
+  polisci: ['plsc'],
+};
+
+// Match quality tiers (higher = stronger match)
+const Q_EXACT = 4; // Subject/number/building prefix
+const Q_NAME = 3; // Subject full name
+const Q_SUBSTR = 2; // Title/professor/description substring
+const Q_FUZZY = 1; // Typo tolerance
+
+/** Returns the match quality for a single token (0 = no match). */
+function tokenMatchesListing(
+  token: string,
+  listing: CatalogListing,
+  options: { searchDescription: boolean },
+): number {
+  const numberFirstChar = listing.number.charAt(0);
+
+  // Structural code matches
+  if (
+    listing.subject.toLowerCase().startsWith(token) ||
+    listing.number.toLowerCase().startsWith(token) ||
+    (/\D/u.test(numberFirstChar) &&
+      listing.number
+        .toLowerCase()
+        .startsWith(numberFirstChar.toLowerCase() + token)) ||
+    listing.course.course_meetings.some(({ location }) =>
+      location?.building.code.toLowerCase().startsWith(token),
+    )
+  )
+    return Q_EXACT;
+
+  // Subject full name ("Computer Science" for CPSC)
+  if (subjects[listing.subject]?.toLowerCase().includes(token)) return Q_NAME;
+
+  // Content substring matches
+  if (
+    listing.course.title.toLowerCase().includes(token) ||
+    (options.searchDescription &&
+      listing.course.description?.toLowerCase().includes(token)) ||
+    listing.course.course_professors.some((p) =>
+      p.professor.name.toLowerCase().includes(token),
+    )
+  )
+    return Q_SUBSTR;
+
+  // Fuzzy fallback
+  const maxDist = token.length <= 2 ? 0 : token.length <= 4 ? 1 : 2;
+  if (maxDist > 0) {
+    const subjectName = subjects[listing.subject];
+    if (
+      fuzzyMatchesAnyWord(token, listing.course.title, maxDist) ||
+      (subjectName !== undefined &&
+        fuzzyMatchesAnyWord(token, subjectName, maxDist)) ||
+      listing.course.course_professors.some((p) =>
+        fuzzyMatchesAnyWord(token, p.professor.name, maxDist),
+      )
+    )
+      return Q_FUZZY;
+  }
+
+  return 0;
+}
+
+/**
+ * Returns a match quality score for the listing against all search tokens.
+ * 0 = no match; 1–4 = matched (higher = stronger).
+ * Overall quality is the minimum across all tokens (AND semantics).
+ */
+export function searchMatchQuality(
+  listing: CatalogListing,
+  tokens: string[],
+  options: { searchDescription: boolean },
+): number {
+  if (tokens.length === 0) return Q_EXACT;
+
+  let min = Q_EXACT;
+  for (const token of tokens) {
+    let q = tokenMatchesListing(token, listing, options);
+
+    // Alias expansion fallback
+    if (q === 0) {
+      const aliases = searchAliases[token];
+      if (aliases) {
+        for (const alias of aliases) {
+          const aq = tokenMatchesListing(alias, listing, options);
+          if (aq > 0) {
+            q = aq;
+            break;
+          }
+        }
+      }
+    }
+
+    if (q === 0) return 0;
+    if (q < min) min = q;
+  }
+
+  return min;
+}
+
+/**
  * Returns true if the listing matches all search tokens (AND across tokens).
  * Tokens are expected to be lowercase.
  */
@@ -10,35 +168,5 @@ export function matchesSearchText(
   tokens: string[],
   options: { searchDescription: boolean },
 ): boolean {
-  for (const token of tokens) {
-    // First character of the course number
-    const numberFirstChar = listing.number.charAt(0);
-    if (
-      listing.subject.toLowerCase().startsWith(token) ||
-      listing.number.toLowerCase().startsWith(token) ||
-      // For course numbers that start with a letter,
-      // exclude this letter when comparing with the search token
-      (/\D/u.test(numberFirstChar) &&
-        listing.number
-          .toLowerCase()
-          .startsWith(numberFirstChar.toLowerCase() + token)) ||
-      (options.searchDescription &&
-        listing.course.description?.toLowerCase().includes(token)) ||
-      listing.course.title.toLowerCase().includes(token) ||
-      // Also match against department name ("Computer Science" for CPSC)
-      subjects[listing.subject]?.toLowerCase().includes(token) ||
-      listing.course.course_professors.some((p) =>
-        p.professor.name.toLowerCase().includes(token),
-      ) ||
-      listing.course.course_meetings.some(({ location }) =>
-        // Do not match on room numbers
-        location?.building.code.toLowerCase().startsWith(token),
-      )
-    )
-      continue;
-
-    return false;
-  }
-
-  return true;
+  return searchMatchQuality(listing, tokens, options) > 0;
 }

--- a/frontend/src/utilities/course.ts
+++ b/frontend/src/utilities/course.ts
@@ -458,15 +458,22 @@ export function sortCourses(
     type: 'desc' | 'asc';
   },
   numFriends: NumFriendsReturn,
+  matchQuality?: ReadonlyMap<CatalogListing, number>,
 ): CatalogListing[] {
-  return courses.toSorted(
-    (a, b) =>
+  return courses.toSorted((a, b) => {
+    // When search text is active, stronger matches sort first
+    if (matchQuality) {
+      const qDiff = (matchQuality.get(b) ?? 0) - (matchQuality.get(a) ?? 0);
+      if (qDiff !== 0) return qDiff;
+    }
+    return (
       compareByKey(a, b, ordering.key, ordering.type, numFriends) ||
       // Define a stable sort order for courses that compare equal
       compareByKey(a, b, 'season_code', 'desc', numFriends) ||
       compareByKey(a, b, 'course_code', 'asc', numFriends) ||
-      compareByKey(a, b, 'section', 'asc', numFriends),
-  );
+      compareByKey(a, b, 'section', 'asc', numFriends)
+    );
+  });
 }
 
 type CourseWithEnrolled = {


### PR DESCRIPTION
## Improve search matching and ranking

Search is now more flexible and results are ordered more intuitively.

Adds subject full-name matching so queries like `computer science` return CPSC courses, introduces conservative typo tolerance (including common transposition mistakes), and adds a small alias layer for shorthand like `cs` and `polisci`.

Also adds a lightweight match-quality signal so stronger matches appear above weaker ones. Exact and direct matches are prioritized, while fuzzy matches still work but don’t dominate results.

## To test, try:

- `cs`, `cs 201`  
- `computer science`  
- `algorthms`, `intrduction`  
- `orgo`, `polisci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced search with graded match-quality scoring, improving ranking by relevance during text searches
  * Fuzzy/typo-tolerant matching (with safeguards for short tokens) and alias-aware token expansion for broader discovery

* **Tests**
  * Added comprehensive tests covering fuzzy matching, alias behavior, exact-vs-fuzzy distinctions, multi-token AND semantics, and match-quality ranking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->