### PR TITLE
feat: add outgoing friend requests endpoint

### DIFF
--- a/api/src/friends/friends.handlers.ts
+++ b/api/src/friends/friends.handlers.ts
@@ -104,13 +104,19 @@ export const removeFriend = async (
       )
       .returning();
     if (!friendDeleteRes) {
-      // No existing friend; try deleting the friend request
+      // No existing friend; try deleting the friend request (incoming or outgoing)
       const [reqDeleteRes] = await tx
         .delete(studentFriendRequests)
         .where(
-          and(
-            eq(studentFriendRequests.netId, friendNetId),
-            eq(studentFriendRequests.friendNetId, netId),
+          or(
+            and(
+              eq(studentFriendRequests.netId, friendNetId),
+              eq(studentFriendRequests.friendNetId, netId),
+            ),
+            and(
+              eq(studentFriendRequests.netId, netId),
+              eq(studentFriendRequests.friendNetId, friendNetId),
+            ),
           ),
         )
         .returning();
@@ -220,6 +226,46 @@ export const getRequestsForFriend = async (
   });
 
   const requests = friendRequestProfiles.map((profile) => ({
+    netId: profile.netId,
+    name: getVisibleDisplayName(
+      profile,
+      'stranger',
+      normalizeVisibility(profile.nameVisibility, 'public'),
+    ),
+  }));
+
+  res.status(200).json({ requests });
+};
+
+export const getOutgoingRequests = async (
+  req: express.Request,
+  res: express.Response,
+): Promise<void> => {
+  const { netId } = req.user!;
+
+  const outgoingRequestProfiles = await db.transaction(async (tx) => {
+    const outgoingReqs = await tx.query.studentFriendRequests.findMany({
+      where: eq(studentFriendRequests.netId, netId),
+      columns: { friendNetId: true },
+    });
+
+    const pendingNetIds = outgoingReqs.map((r) => r.friendNetId);
+
+    if (pendingNetIds.length === 0) return [];
+    return tx
+      .select({
+        netId: studentBluebookSettings.netId,
+        firstName: studentBluebookSettings.firstName,
+        lastName: studentBluebookSettings.lastName,
+        preferredFirstName: studentBluebookSettings.preferredFirstName,
+        preferredLastName: studentBluebookSettings.preferredLastName,
+        nameVisibility: studentBluebookSettings.nameVisibility,
+      })
+      .from(studentBluebookSettings)
+      .where(inArray(studentBluebookSettings.netId, pendingNetIds));
+  });
+
+  const requests = outgoingRequestProfiles.map((profile) => ({
     netId: profile.netId,
     name: getVisibleDisplayName(
       profile,

--- a/api/src/friends/friends.routes.ts
+++ b/api/src/friends/friends.routes.ts
@@ -7,6 +7,7 @@ import {
   getFriendsWorksheets,
   requestAddFriend,
   getRequestsForFriend,
+  getOutgoingRequests,
   getNames,
 } from './friends.handlers.js';
 import { authBasic } from '../auth/auth.handlers.js';
@@ -17,6 +18,10 @@ export default (app: express.Express): void => {
   app.post('/api/friends/remove', asyncHandler(removeFriend));
   app.post('/api/friends/request', asyncHandler(requestAddFriend));
   app.get('/api/friends/getRequests', asyncHandler(getRequestsForFriend));
+  app.get(
+    '/api/friends/getOutgoingRequests',
+    asyncHandler(getOutgoingRequests),
+  );
   app.get('/api/friends/worksheets', asyncHandler(getFriendsWorksheets));
   app.get('/api/friends/names', asyncHandler(getNames));
 };

--- a/docs/api.md
+++ b/docs/api.md
@@ -267,7 +267,22 @@ Endpoints that take a request body may return 400 with `error: "INVALID_REQUEST"
 **Status: 200**
 
 - Body:
-  - `requests`: `array`
+  - `requests`: `array` (incoming: users who have sent a friend request to you)
+    - `netId`: `NetId`
+    - `name`: `string | null`
+
+### `GET` `/api/friends/getOutgoingRequests`
+
+#### Request
+
+- Needs credentials
+
+#### Response
+
+**Status: 200**
+
+- Body:
+  - `requests`: `array` (outgoing: users you have sent a friend request to, still pending)
     - `netId`: `NetId`
     - `name`: `string | null`
 


### PR DESCRIPTION
- Add GET /api/friends/getOutgoingRequests to fetch pending sent requests with display names
- Fix removeFriend to cancel both incoming and outgoing requests (not just incoming)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve pending outgoing friend requests initiated by the user.

* **Bug Fixes**
  * Fixed friend removal to work regardless of request direction.

* **Documentation**
  * Updated API documentation for friend request endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->