### PR TITLE
fix: split first/last name matching in profile search

### DIFF
--- a/api/src/profile/profile.handlers.ts
+++ b/api/src/profile/profile.handlers.ts
@@ -343,6 +343,10 @@ export const searchProfiles = async (
 
   const { q, limit } = queryParse.data;
 
+  const spaceIdx = q.indexOf(' ');
+  const firstPart = spaceIdx !== -1 ? q.slice(0, spaceIdx) : null;
+  const lastPart = spaceIdx !== -1 ? q.slice(spaceIdx + 1) : null;
+
   const candidates = (await db.query.studentBluebookSettings.findMany({
     where: and(
       eq(studentBluebookSettings.profilePageEnabled, true),
@@ -352,6 +356,43 @@ export const searchProfiles = async (
         ilike(studentBluebookSettings.lastName, `%${q}%`),
         ilike(studentBluebookSettings.preferredFirstName, `%${q}%`),
         ilike(studentBluebookSettings.preferredLastName, `%${q}%`),
+        // "First Last" split matching
+        ...(firstPart && lastPart
+          ? [
+              and(
+                or(
+                  ilike(studentBluebookSettings.firstName, `%${firstPart}%`),
+                  ilike(
+                    studentBluebookSettings.preferredFirstName,
+                    `%${firstPart}%`,
+                  ),
+                ),
+                or(
+                  ilike(studentBluebookSettings.lastName, `%${lastPart}%`),
+                  ilike(
+                    studentBluebookSettings.preferredLastName,
+                    `%${lastPart}%`,
+                  ),
+                ),
+              ),
+              and(
+                or(
+                  ilike(studentBluebookSettings.firstName, `%${lastPart}%`),
+                  ilike(
+                    studentBluebookSettings.preferredFirstName,
+                    `%${lastPart}%`,
+                  ),
+                ),
+                or(
+                  ilike(studentBluebookSettings.lastName, `%${firstPart}%`),
+                  ilike(
+                    studentBluebookSettings.preferredLastName,
+                    `%${firstPart}%`,
+                  ),
+                ),
+              ),
+            ]
+          : []),
       ),
     ),
     columns: profileColumns,


### PR DESCRIPTION
## Summary

- The profile search endpoint matched the full query string against each name field individually, so searching `"John Smith"` returned no results even if the user was visible when searching `"John"` alone
- Added cross-field AND conditions that split the query on the first space and match the two parts against first/last name fields (and the reverse order for last-first input)
- Preferred name fields are included in both halves of the split

Fixes #1964