### PR TITLE
feat: display outgoing friend requests and friend name improvements

### DIFF
--- a/api/src/friends/friends.handlers.ts
+++ b/api/src/friends/friends.handlers.ts
@@ -104,13 +104,19 @@ export const removeFriend = async (
       )
       .returning();
     if (!friendDeleteRes) {
-      // No existing friend; try deleting the friend request
+      // No existing friend; try deleting the friend request (incoming or outgoing)
       const [reqDeleteRes] = await tx
         .delete(studentFriendRequests)
         .where(
-          and(
-            eq(studentFriendRequests.netId, friendNetId),
-            eq(studentFriendRequests.friendNetId, netId),
+          or(
+            and(
+              eq(studentFriendRequests.netId, friendNetId),
+              eq(studentFriendRequests.friendNetId, netId),
+            ),
+            and(
+              eq(studentFriendRequests.netId, netId),
+              eq(studentFriendRequests.friendNetId, friendNetId),
+            ),
           ),
         )
         .returning();
@@ -220,6 +226,46 @@ export const getRequestsForFriend = async (
   });
 
   const requests = friendRequestProfiles.map((profile) => ({
+    netId: profile.netId,
+    name: getVisibleDisplayName(
+      profile,
+      'stranger',
+      normalizeVisibility(profile.nameVisibility, 'public'),
+    ),
+  }));
+
+  res.status(200).json({ requests });
+};
+
+export const getOutgoingRequests = async (
+  req: express.Request,
+  res: express.Response,
+): Promise<void> => {
+  const { netId } = req.user!;
+
+  const outgoingRequestProfiles = await db.transaction(async (tx) => {
+    const outgoingReqs = await tx.query.studentFriendRequests.findMany({
+      where: eq(studentFriendRequests.netId, netId),
+      columns: { friendNetId: true },
+    });
+
+    const pendingNetIds = outgoingReqs.map((r) => r.friendNetId);
+
+    if (pendingNetIds.length === 0) return [];
+    return tx
+      .select({
+        netId: studentBluebookSettings.netId,
+        firstName: studentBluebookSettings.firstName,
+        lastName: studentBluebookSettings.lastName,
+        preferredFirstName: studentBluebookSettings.preferredFirstName,
+        preferredLastName: studentBluebookSettings.preferredLastName,
+        nameVisibility: studentBluebookSettings.nameVisibility,
+      })
+      .from(studentBluebookSettings)
+      .where(inArray(studentBluebookSettings.netId, pendingNetIds));
+  });
+
+  const requests = outgoingRequestProfiles.map((profile) => ({
     netId: profile.netId,
     name: getVisibleDisplayName(
       profile,

--- a/api/src/friends/friends.routes.ts
+++ b/api/src/friends/friends.routes.ts
@@ -7,6 +7,7 @@ import {
   getFriendsWorksheets,
   requestAddFriend,
   getRequestsForFriend,
+  getOutgoingRequests,
   getNames,
 } from './friends.handlers.js';
 import { authBasic } from '../auth/auth.handlers.js';
@@ -17,6 +18,10 @@ export default (app: express.Express): void => {
   app.post('/api/friends/remove', asyncHandler(removeFriend));
   app.post('/api/friends/request', asyncHandler(requestAddFriend));
   app.get('/api/friends/getRequests', asyncHandler(getRequestsForFriend));
+  app.get(
+    '/api/friends/getOutgoingRequests',
+    asyncHandler(getOutgoingRequests),
+  );
   app.get('/api/friends/worksheets', asyncHandler(getFriendsWorksheets));
   app.get('/api/friends/names', asyncHandler(getNames));
 };

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "stylelint": "^16.12.0",
         "stylelint-config-standard": "^36.0.1",
         "tsconfig-jc": "^2.3.1",
-        "typescript": "~5.7.3",
+        "typescript": "~6.0.3",
         "typescript-plugin-css-modules": "^5.1.0",
       },
     },
@@ -3131,7 +3131,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.58.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.0", "@typescript-eslint/parser": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA=="],
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -267,7 +267,22 @@ Endpoints that take a request body may return 400 with `error: "INVALID_REQUEST"
 **Status: 200**
 
 - Body:
-  - `requests`: `array`
+  - `requests`: `array` (incoming: users who have sent a friend request to you)
+    - `netId`: `NetId`
+    - `name`: `string | null`
+
+### `GET` `/api/friends/getOutgoingRequests`
+
+#### Request
+
+- Needs credentials
+
+#### Response
+
+**Status: 200**
+
+- Body:
+  - `requests`: `array` (outgoing: users you have sent a friend request to, still pending)
     - `netId`: `NetId`
     - `name`: `string | null`
 

--- a/frontend/src/components/Search/MobileSearchForm.tsx
+++ b/frontend/src/components/Search/MobileSearchForm.tsx
@@ -6,6 +6,7 @@ import { scroller } from 'react-scroll';
 
 import CustomSelect from './CustomSelect';
 import ResultsColumnSort from './ResultsColumnSort';
+import SavedSearchesDropdown from './SavedSearchesDropdown';
 import Toggle from './Toggle';
 import { useSearch } from '../../hooks/useSearch';
 import {
@@ -24,6 +25,7 @@ import {
   type IntersectableFilters,
   type NumericFilters,
 } from '../../search/searchTypes';
+import { useStore } from '../../store';
 import { SurfaceComponent, Input, TextComponent } from '../Typography';
 import styles from './MobileSearchForm.module.css';
 
@@ -142,6 +144,7 @@ function Slider<K extends NumericFilters>({
 
 export default function MobileSearchForm() {
   const { filters, coursesLoading, searchData } = useSearch();
+  const resetSearchFilters = useStore((state) => state.patchSearchFilters);
   const { searchText, selectSortBy } = filters;
   const scrollToResults = useCallback((event?: React.FormEvent) => {
     if (event) event.preventDefault();
@@ -163,19 +166,20 @@ export default function MobileSearchForm() {
   return (
     <SurfaceComponent className={styles.searchContainer}>
       <Form className={styles.searchForm} onSubmit={scrollToResults}>
-        <div className="d-flex justify-content-between pt-4">
-          {/* Reset filters button */}
-          <button
-            type="button"
-            className={clsx(styles.resetFiltersBtn, 'me-auto')}
-            onClick={() => {
-              Object.values(filters).forEach((filter) =>
-                filter.resetToDefault(),
-              );
-            }}
-          >
-            Reset filters
-          </button>
+        <div className="d-flex justify-content-between align-items-center pt-4">
+          <div className="d-flex align-items-center gap-2">
+            {/* Reset filters button */}
+            <button
+              type="button"
+              className={styles.resetFiltersBtn}
+              onClick={() => {
+                resetSearchFilters(defaultFilters);
+              }}
+            >
+              Reset filters
+            </button>
+            <SavedSearchesDropdown />
+          </div>
           {/* Number of results shown text */}
           <small className={clsx(styles.numResults, 'ms-auto')}>
             <TextComponent type="tertiary">

--- a/frontend/src/components/Search/NavbarCatalogSearch.tsx
+++ b/frontend/src/components/Search/NavbarCatalogSearch.tsx
@@ -9,6 +9,7 @@ import { GlobalHotKeys } from 'react-hotkeys';
 import AdvancedPanel from './AdvancedPanel';
 import { Popout } from './Popout';
 import { PopoutSelect } from './PopoutSelect';
+import SavedSearchesDropdown from './SavedSearchesDropdown';
 import { useSearch } from '../../hooks/useSearch';
 import {
   defaultFilters,
@@ -169,6 +170,7 @@ function Slider<K extends NumericFilters>({
 
 export function NavbarCatalogSearch() {
   const isTablet = useStore((state) => state.isTablet);
+  const resetSearchFilters = useStore((state) => state.patchSearchFilters);
   const [searchParams] = useSearchParams();
   const hasCourseModal = searchParams.has('course-modal');
 
@@ -299,14 +301,15 @@ export function NavbarCatalogSearch() {
           )}
           <AdvancedPanel />
 
+          {/* Saved searches dropdown (includes Save current search inside) */}
+          <SavedSearchesDropdown />
+
           {/* Reset filters & sorting button */}
           <Button
             className={styles.resetButton}
             variant="danger"
             onClick={() => {
-              Object.values(filters).forEach((filter) =>
-                filter.resetToDefault(),
-              );
+              resetSearchFilters(defaultFilters);
               setStartTime(Date.now());
             }}
             // Cannot reset if no filters have changed

--- a/frontend/src/components/Search/Popout.tsx
+++ b/frontend/src/components/Search/Popout.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import clsx from 'clsx';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { IoMdArrowDropdown, IoMdArrowDropup } from 'react-icons/io';
 import { IoClose } from 'react-icons/io5';
 import type { Option } from '../../search/searchTypes';
@@ -8,7 +9,9 @@ import styles from './Popout.module.css';
 
 type Props = {
   readonly children: React.ReactNode;
-  readonly buttonText: string;
+  readonly buttonText?: string;
+  readonly ariaLabel?: string;
+  readonly onOpenChange?: (open: boolean) => void;
   readonly onReset?: () => void;
   readonly arrowIcon?: boolean;
   readonly clearIcon?: boolean;
@@ -26,6 +29,7 @@ type Props = {
   readonly colors?: { [optionValue: string]: string };
   readonly dataTutorial?: number;
   readonly Icon?: React.JSX.Element;
+  readonly tooltipText?: string;
   readonly fullWidth?: boolean;
 };
 
@@ -81,6 +85,8 @@ function NotificationIcon({ count }: { readonly count: number }) {
 export function Popout({
   children,
   buttonText,
+  ariaLabel,
+  onOpenChange,
   onReset,
   arrowIcon = true,
   clearIcon = true,
@@ -94,11 +100,18 @@ export function Popout({
   colors,
   dataTutorial,
   Icon,
+  tooltipText,
   fullWidth,
 }: Props) {
+  const tooltipId = useId();
   // Ref to detect outside clicks for popout button and dropdown
   const { toggleRef, dropdownRef, isComponentVisible, setIsComponentVisible } =
     useComponentVisibleDropdown<HTMLButtonElement, HTMLDivElement>(false);
+
+  useEffect(() => {
+    onOpenChange?.(isComponentVisible);
+  }, [isComponentVisible, onOpenChange]);
+
   const text = getText(
     selectedOptions,
     maxDisplayOptions,
@@ -146,6 +159,39 @@ export function Popout({
     else setDropdownXOffset(0);
   }, [isComponentVisible, dropdownXOffset, dropdownRef]);
 
+  const triggerButton = (
+    <button
+      type="button"
+      onClick={() => setIsComponentVisible(!isComponentVisible)}
+      style={buttonStyles(isComponentVisible)}
+      ref={toggleRef}
+      className={clsx(
+        className,
+        styles.button,
+        fullWidth && styles.buttonFullWidth,
+      )}
+      data-tutorial={dataTutorial ? `catalog-${dataTutorial}` : ''}
+      aria-label={ariaLabel}
+    >
+      {Icon ?? null}
+      {text || buttonText ? <div>{text ?? buttonText}</div> : null}
+
+      {text && clearIcon ? (
+        <IoClose
+          className={styles.clearIcon}
+          onClick={(e) => {
+            // Prevent parent popout onClick from toggling the dropdown
+            e.stopPropagation();
+            onReset?.();
+          }}
+        />
+      ) : arrowIcon ? (
+        <ArrowIcon className={styles.arrowIcon} />
+      ) : null}
+      {notifications ? <NotificationIcon count={notifications} /> : null}
+    </button>
+  );
+
   return (
     <div
       data-tutorial={
@@ -157,37 +203,16 @@ export function Popout({
         wrapperClassName,
       )}
     >
-      {/* Popout button */}
-      <button
-        type="button"
-        onClick={() => setIsComponentVisible(!isComponentVisible)}
-        style={buttonStyles(isComponentVisible)}
-        ref={toggleRef}
-        className={clsx(
-          className,
-          styles.button,
-          fullWidth && styles.buttonFullWidth,
-        )}
-        data-tutorial={dataTutorial ? `catalog-${dataTutorial}` : ''}
-      >
-        {Icon ?? null}
-        <div>{text ?? buttonText}</div>
-
-        {text && clearIcon ? (
-          <IoClose
-            className={styles.clearIcon}
-            onClick={(e) => {
-              // Prevent parent popout button onClick from firing and opening
-              // dropdown
-              e.stopPropagation();
-              onReset?.();
-            }}
-          />
-        ) : arrowIcon ? (
-          <ArrowIcon className={styles.arrowIcon} />
-        ) : null}
-        {notifications ? <NotificationIcon count={notifications} /> : null}
-      </button>
+      {tooltipText ? (
+        <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip id={tooltipId}>{tooltipText}</Tooltip>}
+        >
+          {triggerButton}
+        </OverlayTrigger>
+      ) : (
+        triggerButton
+      )}
       {isComponentVisible ? (
         <div
           className={clsx(

--- a/frontend/src/components/Search/SavedSearchesDropdown.module.css
+++ b/frontend/src/components/Search/SavedSearchesDropdown.module.css
@@ -1,0 +1,149 @@
+.container {
+  width: 320px;
+  min-width: 320px;
+  max-width: 320px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.dropdownTitle {
+  margin: 0;
+  padding: 0.75rem 1rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.dropdownDescription {
+  margin: 0 1rem 0.75rem;
+  padding: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  line-height: 1.35;
+}
+
+.addInputContainer {
+  padding: 0.5rem 1rem;
+}
+
+.addInputRow {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.addInput {
+  flex: 1;
+  width: 100%;
+  font-size: 0.875rem;
+}
+
+.addInput::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.saveButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: calc(100% - 1rem);
+  margin: 0 0.5rem 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.savedSearchTrigger {
+  margin-left: -2px;
+  margin-right: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.loading,
+.empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.emptyHint {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+.searchList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.searchItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem 0.25rem 1rem;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+  width: 100%;
+  min-width: 0;
+}
+
+.searchItem:hover {
+  background: var(--color-background-hover);
+  border-color: var(--color-primary);
+}
+
+.applyButton {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0.5rem 0;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.searchName {
+  display: block;
+  min-width: 0;
+  font-weight: 500;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deleteButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  border-radius: 0.25rem;
+  transition: all 0.2s;
+}
+
+.deleteButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.deleteButton:hover:not(:disabled) {
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+}

--- a/frontend/src/components/Search/SavedSearchesDropdown.tsx
+++ b/frontend/src/components/Search/SavedSearchesDropdown.tsx
@@ -1,0 +1,297 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { Modal, Button } from 'react-bootstrap';
+import { MdDelete, MdSavedSearch } from 'react-icons/md';
+import { toast } from 'sonner';
+
+import { Popout } from './Popout';
+import { useSearch } from '../../hooks/useSearch';
+import {
+  fetchSavedSearches,
+  deleteSavedSearch,
+  createSavedSearch,
+  type SavedSearch,
+} from '../../queries/api';
+import { defaultFilters } from '../../search/searchConstants';
+import { getFilterValues } from '../../search/searchTypes';
+import {
+  buildSavedSearchQueryString,
+  sanitizeSavedSearchQueryString,
+} from '../../utilities/params';
+import Spinner from '../Spinner';
+import { Input } from '../Typography';
+import styles from './SavedSearchesDropdown.module.css';
+
+interface SavedSearchesDropdownProps {
+  readonly onSearchApplied?: () => void;
+  readonly refreshKey?: number;
+}
+
+export default function SavedSearchesDropdown({
+  onSearchApplied,
+  refreshKey = 0,
+}: SavedSearchesDropdownProps) {
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+  const [searches, setSearches] = useState<SavedSearch[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
+  const [isAddingSearch, setIsAddingSearch] = useState(false);
+  const [isSavingSearch, setIsSavingSearch] = useState(false);
+  const [addingName, setAddingName] = useState('');
+  const addInputRef = useRef<HTMLInputElement>(null);
+  const saveInFlightRef = useRef(false);
+  const { filters } = useSearch();
+  const defaultSavedSearchName = filters.searchText.value.trim();
+
+  useEffect(() => {
+    if (isAddingSearch && addInputRef.current) addInputRef.current.focus();
+  }, [isAddingSearch]);
+
+  const loadSearches = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const result = await fetchSavedSearches();
+      if (result) setSearches(result.data);
+      else setSearches([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) void loadSearches();
+  }, [isOpen, refreshKey, loadSearches]);
+
+  const handleApplySearch = (search: SavedSearch) => {
+    const queryString = sanitizeSavedSearchQueryString(
+      search.queryString,
+      defaultFilters,
+    );
+    void navigate(`/catalog${queryString}`);
+    toast.success(`Filters from ${search.name} applied`);
+    onSearchApplied?.();
+  };
+
+  const cancelAddingSearch = () => {
+    if (saveInFlightRef.current) return;
+    setAddingName('');
+    setIsAddingSearch(false);
+  };
+
+  const finishSavingSearch = () => {
+    saveInFlightRef.current = false;
+    setIsSavingSearch(false);
+  };
+
+  const saveCurrentSearch = async (rawName: string) => {
+    const name = rawName.trim();
+    if (!name || saveInFlightRef.current) return;
+
+    if (searches.some((search) => search.name === name)) {
+      toast.error('A saved search with this name already exists');
+      return;
+    }
+
+    saveInFlightRef.current = true;
+    setIsSavingSearch(true);
+    try {
+      const filterValues = getFilterValues(filters);
+      const queryString = sanitizeSavedSearchQueryString(
+        buildSavedSearchQueryString(filterValues, defaultFilters),
+        defaultFilters,
+      );
+      const result = await createSavedSearch(name, queryString);
+      if (result) {
+        toast.success('Search saved');
+        setAddingName('');
+        setIsAddingSearch(false);
+        await loadSearches();
+      }
+    } catch (err: unknown) {
+      Sentry.captureException(err);
+    } finally {
+      finishSavingSearch();
+    }
+  };
+
+  const handleDeleteClick = (
+    e: React.MouseEvent,
+    searchId: number,
+    searchName: string,
+  ) => {
+    e.stopPropagation();
+    setDeleteConfirm({ id: searchId, name: searchName });
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteConfirm) return;
+
+    const { id } = deleteConfirm;
+    setDeleteConfirm(null);
+    setDeletingId(id);
+    try {
+      const success = await deleteSavedSearch(id);
+      if (success) {
+        toast.success('Saved search deleted');
+        setSearches((prev) => prev.filter((s) => s.id !== id));
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <>
+      <Popout
+        ariaLabel="Saved Filters / Searches"
+        Icon={<MdSavedSearch size={18} />}
+        className={styles.savedSearchTrigger}
+        tooltipText="Saved Filters / Searches"
+        onOpenChange={setIsOpen}
+      >
+        <div className={styles.container}>
+          <h3 className={styles.dropdownTitle}>Saved Filters / Searches</h3>
+          <p className={styles.dropdownDescription}>
+            Save your current search text and filter combination, or click one
+            to apply it. Saved filters use the currently selected season.
+          </p>
+          {isAddingSearch ? (
+            <div className={styles.addInputContainer}>
+              <div className={styles.addInputRow}>
+                <Input
+                  className={styles.addInput}
+                  type="text"
+                  value={addingName}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setAddingName(e.target.value)
+                  }
+                  placeholder="Name this search..."
+                  maxLength={64}
+                  ref={addInputRef}
+                  disabled={isSavingSearch}
+                  onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                    e.stopPropagation();
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void saveCurrentSearch(addingName);
+                    } else if (e.key === 'Escape') {
+                      cancelAddingSearch();
+                    }
+                  }}
+                  onMouseDown={(e: React.MouseEvent<HTMLInputElement>) =>
+                    e.stopPropagation()
+                  }
+                  onBlur={cancelAddingSearch}
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={isSavingSearch || !addingName.trim()}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    void saveCurrentSearch(addingName);
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button
+              variant="primary"
+              size="sm"
+              className={styles.saveButton}
+              onClick={() => {
+                setAddingName(defaultSavedSearchName);
+                setIsAddingSearch(true);
+              }}
+              title="Save current search"
+            >
+              Save current filters / search
+            </Button>
+          )}
+          {isLoading ? (
+            <div className={styles.loading}>
+              <Spinner message="Loading saved searches..." />
+            </div>
+          ) : searches.length === 0 ? (
+            <div className={styles.empty}>
+              <p>No saved filters or searches yet.</p>
+              <p className={styles.emptyHint}>
+                Save your current filters to quickly return to them later!
+              </p>
+            </div>
+          ) : (
+            <div className={styles.searchList}>
+              {searches.map((search) => (
+                <div key={search.id} className={styles.searchItem}>
+                  <button
+                    type="button"
+                    className={styles.applyButton}
+                    onClick={() => handleApplySearch(search)}
+                  >
+                    <span className={styles.searchName}>{search.name}</span>
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.deleteButton}
+                    onClick={(e) =>
+                      handleDeleteClick(e, search.id, search.name)
+                    }
+                    disabled={deletingId === search.id}
+                    title="Delete saved search"
+                    aria-label={`Delete ${search.name}`}
+                  >
+                    {deletingId === search.id ? (
+                      <Spinner className={styles.spinner} message={undefined} />
+                    ) : (
+                      <MdDelete size={18} />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Popout>
+      <Modal
+        show={deleteConfirm !== null}
+        onHide={() => setDeleteConfirm(null)}
+        centered
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Delete saved search?</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {deleteConfirm && (
+            <>
+              Are you sure you want to delete &quot;{deleteConfirm.name}&quot;?
+              This cannot be undone.
+            </>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setDeleteConfirm(null)}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => {
+              void handleDeleteConfirm().catch((err: unknown) => {
+                Sentry.captureException(err);
+              });
+            }}
+          >
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/components/Worksheet/AddFriendDropdown.module.css
+++ b/frontend/src/components/Worksheet/AddFriendDropdown.module.css
@@ -1,12 +1,8 @@
 .addFriendIcon {
-  margin-top: 4px;
-  cursor: pointer;
   display: block;
 }
 
 .removeFriendIcon {
-  margin-top: 4px;
-  cursor: pointer;
   display: block;
 }
 
@@ -44,4 +40,10 @@
 .spinner {
   height: 20px;
   width: 20px;
+}
+
+.alreadyAddedLabel {
+  color: var(--color-text-secondary);
+  font-size: 0.85em;
+  margin-left: 8px;
 }

--- a/frontend/src/components/Worksheet/AddFriendDropdown.tsx
+++ b/frontend/src/components/Worksheet/AddFriendDropdown.tsx
@@ -25,13 +25,22 @@ import styles from './AddFriendDropdown.module.css';
 
 const FriendContext = createContext<{
   isFriend: (netId: NetId) => boolean;
-  removeFriend: (netId: NetId, isRequest: boolean) => Promise<void>;
+  removeFriend: (
+    netId: NetId,
+    action: 'friend' | 'incoming' | 'outgoing',
+  ) => Promise<void>;
 } | null>(null);
+
+type OptionKind =
+  | 'searchResult'
+  | 'incomingRequest'
+  | 'outgoingRequest'
+  | 'alreadyFriend';
 
 interface OptionType {
   value: NetId;
   label: string;
-  type: 'searchResult' | 'incomingRequest';
+  type: OptionKind;
 }
 
 function OptionWithActionButtons(props: OptionProps<OptionType, false>) {
@@ -57,6 +66,47 @@ function OptionWithActionButtons(props: OptionProps<OptionType, false>) {
       }
     };
 
+  if (data.type === 'alreadyFriend') {
+    return (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
+      <div
+        {...innerProps}
+        className={styles.friendOption}
+        role="button"
+        tabIndex={0}
+      >
+        <span className={styles.friendOptionText}>{children}</span>
+        <span className={styles.alreadyAddedLabel}>Already added</span>
+      </div>
+    );
+  }
+
+  if (data.type === 'outgoingRequest') {
+    return (
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
+      <div
+        {...innerProps}
+        className={styles.friendOption}
+        role="button"
+        tabIndex={0}
+      >
+        <span className={styles.friendOptionText}>{children}</span>
+        {isLoading ? (
+          <Spinner className={styles.spinner} message={undefined} />
+        ) : (
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label="Cancel friend request"
+            onClick={handler((id) => removeFriend(id, 'outgoing'))}
+          >
+            <MdPersonRemove className={styles.removeFriendIcon} />
+          </button>
+        )}
+      </div>
+    );
+  }
+
   if (data.type === 'searchResult') {
     return (
       // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
@@ -70,11 +120,14 @@ function OptionWithActionButtons(props: OptionProps<OptionType, false>) {
         {isLoading ? (
           <Spinner className={styles.spinner} message={undefined} />
         ) : (
-          <MdPersonAdd
-            className={styles.addFriendIcon}
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label="Send friend request"
             onClick={handler(requestAddFriend)}
-            title="Send friend request"
-          />
+          >
+            <MdPersonAdd className={styles.addFriendIcon} />
+          </button>
         )}
       </div>
     );
@@ -97,7 +150,7 @@ function OptionWithActionButtons(props: OptionProps<OptionType, false>) {
             type="button"
             className={clsx(styles.iconButton, styles.iconButtonRemove)}
             aria-label="Decline friend request"
-            onClick={handler((id) => removeFriend(id, true))}
+            onClick={handler((id) => removeFriend(id, 'incoming'))}
           >
             <MdPersonRemove className={styles.removeFriendIcon} />
           </button>
@@ -155,10 +208,11 @@ function AddFriendDropdownDesktop({
 }: {
   readonly fullWidth: boolean;
 }) {
-  const { user, friendRequests } = useStore(
+  const { user, friendRequests, outgoingFriendRequests } = useStore(
     useShallow((state) => ({
       user: state.user,
       friendRequests: state.friendRequests,
+      outgoingFriendRequests: state.outgoingFriendRequests,
     })),
   );
   const navigate = useNavigate();
@@ -183,19 +237,23 @@ function AddFriendDropdownDesktop({
         try {
           const data = await searchProfiles(searchText, 20);
           if (cancelled) return;
+          const outgoingSet = new Set(
+            outgoingFriendRequests?.map((r) => r.netId) ?? [],
+          );
           const nextResults =
             data?.profiles
-              .filter(
-                (profile) =>
-                  profile.netId !== user?.netId && !isFriend(profile.netId),
-              )
+              .filter((profile) => profile.netId !== user?.netId)
               .map(
                 (profile): OptionType => ({
                   value: profile.netId,
                   label: profile.displayName
                     ? `${profile.displayName} (${profile.netId})`
                     : profile.netId,
-                  type: 'searchResult',
+                  type: isFriend(profile.netId)
+                    ? 'alreadyFriend'
+                    : outgoingSet.has(profile.netId)
+                      ? 'outgoingRequest'
+                      : 'searchResult',
                 }),
               ) ?? [];
           setSearchResults(nextResults);
@@ -209,7 +267,7 @@ function AddFriendDropdownDesktop({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [isFriend, searchText, user?.netId]);
+  }, [isFriend, outgoingFriendRequests, searchText, user?.netId]);
   const friendRequestOptions = useMemo(
     (): OptionType[] =>
       friendRequests?.map((request) => ({
@@ -259,7 +317,10 @@ function AddFriendDropdown({
   mobile,
   fullWidth = false,
 }: {
-  readonly removeFriend: (netId: NetId, isRequest: boolean) => Promise<void>;
+  readonly removeFriend: (
+    netId: NetId,
+    action: 'friend' | 'incoming' | 'outgoing',
+  ) => Promise<void>;
   readonly mobile: boolean;
   readonly fullWidth?: boolean;
 }) {

--- a/frontend/src/components/Worksheet/FriendsDropdown.tsx
+++ b/frontend/src/components/Worksheet/FriendsDropdown.tsx
@@ -53,7 +53,10 @@ function OptionWithActionButtons({
   const [isLoading, setIsLoading] = useState(false);
   // Passed from the PopoutSelect
   const { removeFriend } = props.selectProps as unknown as {
-    removeFriend: (netId: NetId, isRequest: boolean) => Promise<void>;
+    removeFriend: (
+      netId: NetId,
+      action: 'friend' | 'incoming' | 'outgoing',
+    ) => Promise<void>;
   };
   if (props.data.value === 'me') {
     return (
@@ -72,7 +75,7 @@ function OptionWithActionButtons({
             e.preventDefault();
             e.stopPropagation();
             setIsLoading(true);
-            await removeFriend(props.data.value as NetId, false);
+            await removeFriend(props.data.value as NetId, 'friend');
             setIsLoading(false);
           }}
           title="Remove friend"
@@ -89,7 +92,10 @@ function FriendsDropdownDesktop({
 }: {
   readonly options: Option<NetId | 'me'>[];
   readonly viewedPerson: Option<NetId> | null;
-  readonly removeFriend: (netId: NetId, isRequest: boolean) => Promise<void>;
+  readonly removeFriend: (
+    netId: NetId,
+    action: 'friend' | 'incoming' | 'outgoing',
+  ) => Promise<void>;
 }) {
   const changeViewedPerson = useStore((state) => state.changeViewedPerson);
   return (
@@ -130,7 +136,7 @@ function FriendsDropdown({
       readonly mobile: false;
       readonly removeFriend: (
         netId: NetId,
-        isRequest: boolean,
+        action: 'friend' | 'incoming' | 'outgoing',
       ) => Promise<void>;
     }) {
   const friends = useStore((state) => state.friends);

--- a/frontend/src/components/Worksheet/NavbarWorksheetSearch.tsx
+++ b/frontend/src/components/Worksheet/NavbarWorksheetSearch.tsx
@@ -57,12 +57,17 @@ export function NavbarWorksheetSearch({
   const isMapSelected = worksheetView === 'map';
 
   const removeFriendWithConfirmation = useCallback(
-    (friendNetId: NetId, isRequest: boolean) =>
+    (friendNetId: NetId, action: 'friend' | 'incoming' | 'outgoing') =>
       new Promise<void>((resolve) => {
+        const actionLabel =
+          action === 'outgoing'
+            ? 'cancel your friend request to'
+            : action === 'incoming'
+              ? 'decline the friend request from'
+              : 'remove';
         toast.warning(
           <div>
-            You are about to {isRequest ? 'decline a request from' : 'remove'}{' '}
-            {friendNetId}.
+            You are about to {actionLabel} {friendNetId}.
             <br />
             <b>This is irreversible without another friend request.</b>
             <br />
@@ -71,9 +76,9 @@ export function NavbarWorksheetSearch({
             <LinkLikeText
               className="me-2"
               onClick={async () => {
-                if (!isRequest && viewedPerson === friendNetId)
+                if (action === 'friend' && viewedPerson === friendNetId)
                   changeViewedPerson('me');
-                await removeFriend(friendNetId, isRequest);
+                await removeFriend(friendNetId, action);
                 resolve();
                 toast.dismiss(`remove-${friendNetId}`);
               }}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -77,6 +77,7 @@ const selectProfileStore = (state: Store) => ({
   worksheetsRefresh: state.worksheetsRefresh,
   friends: state.friends,
   friendRequests: state.friendRequests,
+  outgoingFriendRequests: state.outgoingFriendRequests,
   friendRefresh: state.friendRefresh,
   friendReqRefresh: state.friendReqRefresh,
   removeFriend: state.removeFriend,
@@ -119,6 +120,7 @@ function Profile() {
     worksheetsRefresh,
     friends,
     friendRequests,
+    outgoingFriendRequests,
     friendRefresh,
     friendReqRefresh,
     removeFriend,
@@ -261,12 +263,17 @@ function Profile() {
   );
 
   const removeFriendWithConfirmation = useCallback(
-    (friendNetId: NetId, isRequest: boolean) =>
+    (friendNetId: NetId, action: 'friend' | 'incoming' | 'outgoing') =>
       new Promise<void>((resolve) => {
+        const actionLabel =
+          action === 'outgoing'
+            ? 'cancel your friend request to'
+            : action === 'incoming'
+              ? 'decline the friend request from'
+              : 'remove';
         toast.warning(
           <div>
-            You are about to {isRequest ? 'decline a request from' : 'remove'}{' '}
-            {friendNetId}.
+            You are about to {actionLabel} {friendNetId}.
             <br />
             <b>This is irreversible without another friend request.</b>
             <br />
@@ -275,7 +282,7 @@ function Profile() {
             <LinkLikeText
               className="me-2"
               onClick={async () => {
-                await removeFriend(friendNetId, isRequest);
+                await removeFriend(friendNetId, action);
                 resolve();
                 toast.dismiss(`remove-${friendNetId}`);
               }}
@@ -314,7 +321,8 @@ function Profile() {
   const hasName = Boolean(currentUser.firstName && currentUser.lastName);
   const friendsList = friends ? Object.entries(friends) : [];
   const friendRequestsList = friendRequests ?? [];
-  const friendsLoading = !friends || !friendRequests;
+  const outgoingFriendRequestsList = outgoingFriendRequests ?? [];
+  const friendsLoading = !friends || !friendRequests || !outgoingFriendRequests;
   const worksheetsLoading = !worksheets || profileWorksheetCatalogLoading;
 
   const handleCatalogCacheRefresh = async () => {
@@ -505,7 +513,7 @@ function Profile() {
                   {!friendsLoading && friendRequestsList.length > 0 && (
                     <div className={styles.friendRequests}>
                       <TextComponent type="secondary">
-                        Pending requests
+                        Incoming requests
                       </TextComponent>
                       {friendRequestsList.map((request) => (
                         <div
@@ -539,11 +547,51 @@ function Profile() {
                               onClick={() => {
                                 void removeFriendWithConfirmation(
                                   request.netId,
-                                  true,
+                                  'incoming',
                                 );
                               }}
                             >
                               Decline
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {!friendsLoading && outgoingFriendRequestsList.length > 0 && (
+                    <div className={styles.friendRequests}>
+                      <TextComponent type="secondary">
+                        Pending requests
+                      </TextComponent>
+                      {outgoingFriendRequestsList.map((request) => (
+                        <div
+                          key={request.netId}
+                          className={styles.friendRequestItem}
+                        >
+                          <Link
+                            to={`/u/${request.netId}`}
+                            className={clsx(
+                              styles.friendProfileLink,
+                              styles.friendRowLink,
+                            )}
+                          >
+                            <TextComponent>
+                              {request.name || request.netId}
+                            </TextComponent>
+                          </Link>
+                          <div className={styles.friendActions}>
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              onClick={() => {
+                                void removeFriendWithConfirmation(
+                                  request.netId,
+                                  'outgoing',
+                                );
+                              }}
+                            >
+                              Cancel
                             </Button>
                           </div>
                         </div>
@@ -583,7 +631,7 @@ function Profile() {
                               onClick={() => {
                                 void removeFriendWithConfirmation(
                                   friendNetId as NetId,
-                                  false,
+                                  'friend',
                                 );
                               }}
                             >

--- a/frontend/src/queries/api.ts
+++ b/frontend/src/queries/api.ts
@@ -931,6 +931,18 @@ export function fetchFriendReqs() {
   });
 }
 
+export function fetchOutgoingFriendReqs() {
+  return fetchAPI('/friends/getOutgoingRequests', {
+    schema: z.object({
+      requests: friendRequestsSchema,
+    }),
+    breadcrumb: {
+      category: 'friends',
+      message: 'Fetching outgoing friend requests',
+    },
+  });
+}
+
 const userNamesSchema = z.array(
   z.object({
     netId: netIdSchema,
@@ -1045,4 +1057,66 @@ export async function checkAuth() {
   }
   if (res.auth) Sentry.setUser({ username: res.netId });
   return res.auth;
+}
+
+// Saved Searches API
+
+const savedSearchSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  queryString: z.string(),
+  createdAt: z.number(),
+});
+
+export type SavedSearch = z.infer<typeof savedSearchSchema>;
+
+export async function fetchSavedSearches() {
+  return await fetchAPI(`/savedSearches?_=${Date.now()}`, {
+    schema: z.object({
+      data: z.array(savedSearchSchema),
+    }),
+    breadcrumb: {
+      category: 'savedSearches',
+      message: 'Fetching saved searches',
+    },
+  });
+}
+
+export async function createSavedSearch(name: string, queryString: string) {
+  return await fetchAPI('/savedSearches/create', {
+    body: { name, queryString },
+    schema: savedSearchSchema,
+    breadcrumb: {
+      category: 'savedSearches',
+      message: 'Creating saved search',
+    },
+    handleErrorCode(err) {
+      switch (err) {
+        case 'DUPLICATE_NAME':
+          toast.error('A saved search with this name already exists');
+          return true;
+        default:
+          return false;
+      }
+    },
+  });
+}
+
+export async function deleteSavedSearch(id: number) {
+  return await fetchAPI('/savedSearches/delete', {
+    body: { id },
+    breadcrumb: {
+      category: 'savedSearches',
+      message: 'Deleting saved search',
+    },
+    handleErrorCode(err) {
+      switch (err) {
+        case 'SEARCH_NOT_FOUND':
+          toast.error('Saved search not found');
+          return true;
+        default:
+          return false;
+      }
+    },
+  });
 }

--- a/frontend/src/search/SearchBootstrap.tsx
+++ b/frontend/src/search/SearchBootstrap.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   type SetStateAction,
 } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
@@ -44,50 +45,69 @@ import {
   toRangeTime,
   toWeekdayStrings,
 } from '../utilities/course';
-import { createFilterLink, getFilterFromParams } from '../utilities/params';
+import {
+  buildCatalogSearchParams,
+  getFilterFromParams,
+} from '../utilities/params';
+
+type PendingUrlHydration = {
+  search: string;
+  updates: Partial<Filters>;
+};
+
+function hasAppliedHydration(
+  searchFilters: Filters,
+  updates: Partial<Filters>,
+) {
+  return (Object.keys(updates) as (keyof Filters)[]).every((key) => {
+    const value = updates[key];
+    return value === undefined || isEqual(searchFilters[key], value);
+  });
+}
 
 function useSearchUrlHydration() {
   const location = useLocation();
-  const [searchParams] = useSearchParams();
   const patchSearchFilters = useStore((s) => s.patchSearchFilters);
+  const pendingHydrationRef = useRef<PendingUrlHydration | null>(null);
+  const clearPendingHydration = useCallback(() => {
+    pendingHydrationRef.current = null;
+  }, []);
 
   useLayoutEffect(() => {
     if (location.pathname !== '/catalog') return;
+    const { searchFilters } = useStore.getState();
+    const searchParams = new URLSearchParams(location.search);
     const updates = SEARCH_FILTER_KEYS.reduce<Partial<Filters>>((acc, key) => {
       const urlValue = searchParams.get(key);
-      if (urlValue === null) return acc;
+      if (urlValue === null && key === 'selectSeasons') return acc;
       try {
-        return {
-          ...acc,
-          [key]: getFilterFromParams(key, urlValue, defaultFilters[key]),
-        };
+        const next =
+          urlValue === null
+            ? defaultFilters[key]
+            : getFilterFromParams(key, urlValue, defaultFilters[key]);
+        if (isEqual(searchFilters[key], next)) return acc;
+        return { ...acc, [key]: next };
       } catch {
         return acc;
       }
     }, {});
-    if (Object.keys(updates).length > 0) patchSearchFilters(updates);
-  }, [location.pathname, patchSearchFilters, searchParams]);
+    if (Object.keys(updates).length > 0) {
+      pendingHydrationRef.current = {
+        search: location.search,
+        updates,
+      };
+      patchSearchFilters(updates);
+    } else {
+      pendingHydrationRef.current = null;
+    }
+  }, [location.pathname, location.search, patchSearchFilters]);
+
+  return { clearPendingHydration, pendingHydrationRef };
 }
 
 function useFilterState<K extends keyof Filters>(key: K): FilterHandle<K> {
-  const location = useLocation();
-  const [, setSearchParams] = useSearchParams();
   const value = useStore((s) => s.searchFilters[key]);
   const setSearchFilter = useStore((s) => s.setSearchFilter);
-
-  useEffect(() => {
-    if (location.pathname === '/catalog') {
-      try {
-        const newUrl = createFilterLink(key, value, defaultFilters[key]);
-        if (newUrl !== location.search) {
-          sessionStorage.setItem('lastCatalogSearch', newUrl);
-          setSearchParams(new URLSearchParams(newUrl.slice(1)));
-        }
-      } catch {
-        /* Ignore */
-      }
-    }
-  }, [key, value, location.pathname, location.search, setSearchParams]);
 
   return useMemo(
     () => ({
@@ -106,6 +126,49 @@ function useFilterState<K extends keyof Filters>(key: K): FilterHandle<K> {
     }),
     [value, key, setSearchFilter],
   );
+}
+
+function useSearchUrlSync(
+  pendingHydrationRef: React.RefObject<PendingUrlHydration | null>,
+  clearPendingHydration: () => void,
+) {
+  const location = useLocation();
+  const [, setSearchParams] = useSearchParams();
+  const searchFilters = useStore((s) => s.searchFilters);
+
+  useEffect(() => {
+    if (location.pathname !== '/catalog') return;
+    const pendingHydration = pendingHydrationRef.current;
+    if (
+      pendingHydration?.search === location.search &&
+      !hasAppliedHydration(searchFilters, pendingHydration.updates)
+    )
+      return;
+    if (pendingHydration?.search === location.search) clearPendingHydration();
+
+    const searchParams = new URLSearchParams(location.search);
+    const nextParams = buildCatalogSearchParams(
+      searchFilters,
+      defaultFilters,
+      searchParams,
+    );
+    const nextSearch = nextParams.toString();
+
+    if (nextSearch === searchParams.toString()) return;
+
+    sessionStorage.setItem(
+      'lastCatalogSearch',
+      nextSearch ? `?${nextSearch}` : '',
+    );
+    setSearchParams(nextParams);
+  }, [
+    location.pathname,
+    location.search,
+    clearPendingHydration,
+    pendingHydrationRef,
+    searchFilters,
+    setSearchParams,
+  ]);
 }
 
 const targetTypes = {
@@ -194,7 +257,9 @@ export function SearchBootstrap({
 }: {
   readonly children: React.ReactNode;
 }) {
-  useSearchUrlHydration();
+  const { clearPendingHydration, pendingHydrationRef } =
+    useSearchUrlHydration();
+  useSearchUrlSync(pendingHydrationRef, clearPendingHydration);
 
   const searchText = useFilterState('searchText');
   const selectSubjects = useFilterState('selectSubjects');

--- a/frontend/src/search/searchTypes.ts
+++ b/frontend/src/search/searchTypes.ts
@@ -97,3 +97,13 @@ export type FilterHandle<K extends keyof Filters> = {
 };
 
 export type FilterList = { [K in keyof Filters]: FilterHandle<K> };
+
+/** Raw filter object from FilterList (e.g. URL / API). */
+export function getFilterValues(filterList: FilterList): Filters {
+  return Object.fromEntries(
+    (Object.keys(filterList) as (keyof Filters)[]).map((k) => [
+      k,
+      filterList[k].value,
+    ]),
+  ) as Filters;
+}

--- a/frontend/src/slices/UserSlice.ts
+++ b/frontend/src/slices/UserSlice.ts
@@ -5,6 +5,7 @@ import {
   fetchUserWorksheets,
   fetchFriendWorksheets,
   fetchFriendReqs,
+  fetchOutgoingFriendReqs,
   addFriend as baseAddFriend,
   requestAddFriend as baseRequestAddFriend,
   removeFriend as baseRemoveFriend,
@@ -23,6 +24,7 @@ interface UserState {
   worksheets?: UserWorksheets;
   wishlist?: WishlistItem[];
   friendRequests?: FriendRequests;
+  outgoingFriendRequests?: FriendRequests;
   friends?: FriendRecord;
   sameCourseIdToCrns?: { [key: string]: number[] };
 }
@@ -34,7 +36,10 @@ interface UserActions {
   friendRefresh: () => Promise<void>;
   friendReqRefresh: () => Promise<void>;
   addFriend: (friendNetId: NetId) => Promise<void>;
-  removeFriend: (friendNetId: NetId, isRequest: boolean) => Promise<void>;
+  removeFriend: (
+    friendNetId: NetId,
+    action: 'friend' | 'incoming' | 'outgoing',
+  ) => Promise<void>;
   requestAddFriend: (friendNetId: NetId) => Promise<void>;
 }
 
@@ -48,6 +53,7 @@ export const createUserSlice: StateCreator<Store, [], [], UserSlice> = (
   worksheets: undefined,
   wishlist: undefined,
   friendRequests: undefined,
+  outgoingFriendRequests: undefined,
   friends: undefined,
   sameCourseIdToCrns: undefined,
   async userRefresh() {
@@ -70,19 +76,32 @@ export const createUserSlice: StateCreator<Store, [], [], UserSlice> = (
     });
   },
   async friendReqRefresh() {
-    const data = await fetchFriendReqs();
-    set({ friendRequests: data?.requests });
+    const [data, outgoingData] = await Promise.all([
+      fetchFriendReqs(),
+      fetchOutgoingFriendReqs(),
+    ]);
+    set({
+      friendRequests: data?.requests,
+      outgoingFriendRequests: outgoingData?.requests,
+    });
   },
   async addFriend(friendNetId: NetId) {
     if (await baseAddFriend(friendNetId))
       toast.info(`Added friend: ${friendNetId}`);
     await Promise.all([get().friendRefresh(), get().friendReqRefresh()]);
   },
-  async removeFriend(friendNetId: NetId, isRequest: boolean) {
+  async removeFriend(
+    friendNetId: NetId,
+    action: 'friend' | 'incoming' | 'outgoing',
+  ) {
     if (await baseRemoveFriend(friendNetId)) {
-      toast.info(
-        `${isRequest ? 'Declined request from' : 'Removed friend'} ${friendNetId}`,
-      );
+      const msg =
+        action === 'friend'
+          ? `Removed friend ${friendNetId}`
+          : action === 'outgoing'
+            ? `Cancelled friend request to ${friendNetId}`
+            : `Declined friend request from ${friendNetId}`;
+      toast.info(msg);
     }
     await Promise.all([get().friendRefresh(), get().friendReqRefresh()]);
   },
@@ -98,8 +117,13 @@ export const createUserSlice: StateCreator<Store, [], [], UserSlice> = (
       toast.error(
         `You already received a friend request from ${friendNetId}. Go approve the request instead!`,
       );
+    } else if (
+      get().outgoingFriendRequests?.find((x) => x.netId === friendNetId)
+    ) {
+      toast.error(`You already sent a friend request to ${friendNetId}.`);
     } else if (await baseRequestAddFriend(friendNetId)) {
       toast.info(`Sent friend request: ${friendNetId}`);
+      await get().friendReqRefresh();
     }
   },
 });

--- a/frontend/src/utilities/display.tsx
+++ b/frontend/src/utilities/display.tsx
@@ -97,14 +97,17 @@ export function useComponentVisibleDropdown<
 
   const handleClickOutside = (event: Event) => {
     // Hide component if user clicked outside of it
+    const target = event.target as Node;
     const portal = document.querySelector('#portal');
+    const isModalClick =
+      target instanceof Element && target.closest('.modal, .modal-backdrop');
     if (
       toggleRef.current &&
       dropdownRef.current &&
-      !toggleRef.current.contains(event.target as Node) &&
-      !dropdownRef.current.contains(event.target as Node) &&
-      portal &&
-      !portal.contains(event.target as Node)
+      !toggleRef.current.contains(target) &&
+      !dropdownRef.current.contains(target) &&
+      !isModalClick &&
+      (!portal || !portal.contains(target))
     ) {
       if (callback) callback(isComponentVisible);
 

--- a/frontend/src/utilities/navigation.ts
+++ b/frontend/src/utilities/navigation.ts
@@ -1,4 +1,8 @@
 export function createCatalogLink(path = '/catalog'): string {
   const lastSearch = sessionStorage.getItem('lastCatalogSearch');
-  return `${path}${lastSearch || ''}`;
+  // Reject corrupt or default-only URLs (e.g. [object Object], empty params)
+  if (!lastSearch || lastSearch === '?' || lastSearch.includes('object+Object'))
+    return path;
+
+  return `${path}${lastSearch}`;
 }

--- a/frontend/src/utilities/params.ts
+++ b/frontend/src/utilities/params.ts
@@ -1,14 +1,43 @@
-import { schools, skillsAreas, subjects, weekdays } from './constants';
+import { isEqual } from './common';
+import {
+  courseInfoAttributes,
+  credits,
+  schools,
+  skillsAreas,
+  subjects,
+  weekdays,
+} from './constants';
 import { toSeasonString } from './course';
 import type { Season } from '../queries/graphql-types';
-import type { Filters, SortKeys } from '../search/searchTypes';
+import {
+  booleanAttributes,
+  sortByOptions,
+  type BooleanAttributes,
+  type Filters,
+  type SortKeys,
+} from '../search/searchTypes';
+
+// List of filter params where an empty url value means an empty array
+const EMPTY_ARRAY_PARAM_KEYS = new Set<keyof Filters>([
+  'selectCourseInfoAttributes',
+  'selectCredits',
+  'selectDays',
+  'selectSchools',
+  'selectSeasons',
+  'selectSkillsAreas',
+  'selectSubjects',
+  'selectBuilding',
+  'intersectingFilters',
+  'includeAttributes',
+  'excludeAttributes',
+]);
 
 export function getFilterFromParams<K extends keyof Filters>(
   key: K,
   value: string,
   fallback: Filters[K],
 ): Filters[K] {
-  if (value === '') return fallback;
+  if (value === '') return getEmptyFilterFromParams(key, fallback);
 
   try {
     const result = ((): Filters[K] => {
@@ -25,16 +54,16 @@ export function getFilterFromParams<K extends keyof Filters>(
         case 'hideCancelled':
         case 'hideConflicting':
         case 'searchDescription':
-          return handleBooleanFilter(value);
+          return handleBooleanFilter(value, fallback);
 
         case 'searchText':
           return value as Filters[K];
 
         case 'selectSortBy':
-          return handleSortByFilter(value);
+          return handleSortByFilter(value, fallback);
 
         case 'sortOrder':
-          return handleSortOrderFilter(value);
+          return handleSortOrderFilter(value, fallback);
 
         case 'selectCourseInfoAttributes':
         case 'selectCredits':
@@ -51,7 +80,7 @@ export function getFilterFromParams<K extends keyof Filters>(
 
         case 'includeAttributes':
         case 'excludeAttributes':
-          return value.split(',') as Filters[K];
+          return handleBooleanAttributesParam(value, fallback);
 
         default:
           console.warn(`Unhandled filter type: ${key}`);
@@ -63,6 +92,15 @@ export function getFilterFromParams<K extends keyof Filters>(
     console.warn(`Error parsing filter ${key}:`, e);
     return fallback;
   }
+}
+
+function getEmptyFilterFromParams<K extends keyof Filters>(
+  key: K,
+  fallback: Filters[K],
+): Filters[K] {
+  if (EMPTY_ARRAY_PARAM_KEYS.has(key)) return [] as unknown as Filters[K];
+  if (key === 'searchText') return '' as Filters[K];
+  return fallback;
 }
 
 function handleBoundsFilter<K extends keyof Filters>(
@@ -81,19 +119,25 @@ function handleBoundsFilter<K extends keyof Filters>(
 
 function handleBooleanFilter<K extends keyof Filters>(
   value: string,
+  fallback: Filters[K],
 ): Filters[K] {
+  if (value !== 'true' && value !== 'false') return fallback;
   return (value === 'true') as Filters[K];
 }
 
 function handleSortByFilter<K extends keyof Filters>(
   value: string,
+  fallback: Filters[K],
 ): Filters[K] {
+  if (!Object.hasOwn(sortByOptions, value)) return fallback;
   return { value: value as SortKeys, label: value } as Filters[K];
 }
 
 function handleSortOrderFilter<K extends keyof Filters>(
   value: string,
+  fallback: Filters[K],
 ): Filters[K] {
+  if (value !== 'asc' && value !== 'desc') return fallback;
   return (value === 'asc' ? 'asc' : 'desc') as Filters[K];
 }
 
@@ -120,11 +164,17 @@ function handleSelectFilter<K extends keyof Filters>(
           return found ? { value: Number(val), label: found[0] } : null;
         }
         case 'selectCredits':
+          if (!credits.some((credit) => String(credit) === val)) return null;
           return {
             value: Number(val),
             label: val,
           };
         case 'selectCourseInfoAttributes':
+          if (!courseInfoAttributes.includes(val)) return null;
+          return {
+            value: val,
+            label: val,
+          };
         case 'selectBuilding':
           return {
             value: val,
@@ -192,32 +242,115 @@ function handleIntersectingFiltersParam<K extends keyof Filters>(
   return filters as Filters[K];
 }
 
-export function createFilterLink<K extends keyof Filters>(
-  key: K,
-  value: Filters[K],
-  defaultValue: Filters[K],
+function handleBooleanAttributesParam<K extends keyof Filters>(
+  value: string,
+  fallback: Filters[K],
+): Filters[K] {
+  const attrs = value.split(',');
+  if (!attrs.every((attr) => Object.hasOwn(booleanAttributes, attr)))
+    return fallback;
+
+  return attrs as BooleanAttributes[] as Filters[K];
+}
+
+function serializeArrayFilterValue(value: readonly unknown[]) {
+  return value
+    .map((v) => {
+      if (typeof v === 'object' && v !== null && Object.hasOwn(v, 'value'))
+        return String((v as { value: string | number }).value);
+      return String(v as string | number);
+    })
+    .join(',');
+}
+
+function serializeFilterValue(value: Filters[keyof Filters]) {
+  if (Array.isArray(value)) return serializeArrayFilterValue(value);
+  if (typeof value === 'object' && Object.hasOwn(value, 'value'))
+    return String((value as { value: string | number }).value);
+  return String(value as string | boolean);
+}
+
+/**
+ * Builds a saved-search query string from filters, excluding defaults and
+ * season.
+ */
+export function buildSavedSearchQueryString(
+  filters: Filters,
+  defaultFilters: Filters,
 ): string {
-  const newSearch = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams();
 
-  if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
-    newSearch.delete(key);
-    return `?${newSearch.toString()}`;
-  }
+  (Object.keys(filters) as (keyof Filters)[]).forEach((key) => {
+    if (key === 'selectSeasons') return;
 
-  if (Array.isArray(value)) {
-    const values = value.map((v) =>
-      typeof v === 'object' && Object.hasOwn(v, 'value') ? v.value : v,
-    );
-    // Avoid `?key=` (empty string): getFilterFromParams treats ''
-    // as "use default", which breaks filters whose empty state differs
-    // from default (e.g. selectSeasons).
-    if (values.length === 0) newSearch.delete(key);
-    else newSearch.set(key, values.join(','));
-  } else if (typeof value === 'object' && Object.hasOwn(value, 'value')) {
-    newSearch.set(key, value.value.toString());
-  } else {
-    newSearch.set(key, value.toString());
-  }
+    const value = filters[key];
+    const defaultValue = defaultFilters[key];
 
-  return `?${newSearch.toString()}`;
+    // Skip if value equals default
+    if (isEqual(value, defaultValue)) return;
+
+    params.set(key, serializeFilterValue(value));
+  });
+
+  const queryString = params.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export function sanitizeSavedSearchQueryString(
+  queryString: string,
+  defaultFilters: Filters,
+): string {
+  const params = new URLSearchParams(
+    queryString.startsWith('?') ? queryString.slice(1) : queryString,
+  );
+  const filters = { ...defaultFilters };
+
+  (Object.keys(defaultFilters) as (keyof Filters)[]).forEach((key) => {
+    if (key === 'selectSeasons') return;
+
+    const value = params.get(key);
+    if (value === null) return;
+
+    filters[key] = getFilterFromParams(
+      key,
+      value,
+      defaultFilters[key],
+    ) as never;
+  });
+
+  return buildSavedSearchQueryString(filters, defaultFilters);
+}
+
+/** Params to preserve when syncing URL (e.g. course-modal, prof-modal). */
+const PRESERVE_PARAMS = new Set(['course-modal', 'prof-modal']);
+
+/**
+ * Builds URLSearchParams from filter state for the catalog, preserving
+ * non-filter params (e.g. course-modal, prof-modal) from the current URL.
+ * Used for centralized single-pass URL sync.
+ */
+export function buildCatalogSearchParams(
+  filters: Filters,
+  defaultFilters: Filters,
+  currentParams: URLSearchParams,
+): URLSearchParams {
+  const result = new URLSearchParams();
+
+  // Copy preserved params first
+  PRESERVE_PARAMS.forEach((key) => {
+    const v = currentParams.get(key);
+    if (v !== null) result.set(key, v);
+  });
+
+  // Add filter params (excluding defaults)
+  (Object.keys(filters) as (keyof Filters)[]).forEach((key) => {
+    const value = filters[key];
+    const defaultValue = defaultFilters[key];
+
+    if (isEqual(value, defaultValue)) return;
+
+    result.set(key, serializeFilterValue(value));
+  });
+
+  return result;
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "stylelint": "^16.12.0",
     "stylelint-config-standard": "^36.0.1",
     "tsconfig-jc": "^2.3.1",
-    "typescript": "~5.7.3",
+    "typescript": "~6.0.3",
     "typescript-plugin-css-modules": "^5.1.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Show outgoing (pending) friend requests in the Add Friend dropdown and Profile page, with a cancel action
- Fix icon alignment for add/remove friend buttons in the dropdown (both icons now use consistent absolute positioning via `iconButton`)
- Replace `isRequest: boolean` with a named `'friend' | 'incoming' | 'outgoing'` action type so confirmation dialogs show context-appropriate messaging:
  - Outgoing: "You are about to cancel your friend request to…"
  - Incoming: "You are about to decline the friend request from…"
  - Friend: "You are about to remove…"

## Test plan

- [ ] Search for a friend and send a request — confirm add icon is aligned
- [ ] View outgoing requests in the dropdown and on the Profile page
- [ ] Cancel an outgoing request — confirm the dialog says "cancel your friend request to"
- [ ] Decline an incoming request — confirm the dialog says "decline the friend request from"
- [ ] Remove an existing friend — confirm the dialog says "remove"