### PR TITLE
fix: first and last friend search fix

### DIFF
--- a/api/src/profile/profile.handlers.ts
+++ b/api/src/profile/profile.handlers.ts
@@ -343,16 +343,46 @@ export const searchProfiles = async (
 
   const { q, limit } = queryParse.data;
 
+  const spaceIdx = q.indexOf(' ');
+  const nameCondition =
+    spaceIdx === -1
+      ? or(
+          ilike(studentBluebookSettings.netId, `%${q}%`),
+          ilike(studentBluebookSettings.firstName, `%${q}%`),
+          ilike(studentBluebookSettings.lastName, `%${q}%`),
+          ilike(studentBluebookSettings.preferredFirstName, `%${q}%`),
+          ilike(studentBluebookSettings.preferredLastName, `%${q}%`),
+        )
+      : (() => {
+          const first = q.slice(0, spaceIdx);
+          const last = q.slice(spaceIdx + 1);
+          const firstFields = or(
+            ilike(studentBluebookSettings.firstName, `%${first}%`),
+            ilike(studentBluebookSettings.preferredFirstName, `%${first}%`),
+          );
+          const lastFields = or(
+            ilike(studentBluebookSettings.lastName, `%${last}%`),
+            ilike(studentBluebookSettings.preferredLastName, `%${last}%`),
+          );
+          // Also try last-first order
+          const lastFirstFields = or(
+            ilike(studentBluebookSettings.lastName, `%${first}%`),
+            ilike(studentBluebookSettings.preferredLastName, `%${first}%`),
+          );
+          const firstLastFields = or(
+            ilike(studentBluebookSettings.firstName, `%${last}%`),
+            ilike(studentBluebookSettings.preferredFirstName, `%${last}%`),
+          );
+          return or(
+            and(firstFields, lastFields),
+            and(lastFirstFields, firstLastFields),
+          );
+        })();
+
   const candidates = (await db.query.studentBluebookSettings.findMany({
     where: and(
       eq(studentBluebookSettings.profilePageEnabled, true),
-      or(
-        ilike(studentBluebookSettings.netId, `%${q}%`),
-        ilike(studentBluebookSettings.firstName, `%${q}%`),
-        ilike(studentBluebookSettings.lastName, `%${q}%`),
-        ilike(studentBluebookSettings.preferredFirstName, `%${q}%`),
-        ilike(studentBluebookSettings.preferredLastName, `%${q}%`),
-      ),
+      nameCondition,
     ),
     columns: profileColumns,
     limit,

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -380,7 +380,7 @@ function WorksheetCalendar({
         localizer={localizer}
         toolbar={false}
         scrollToTime={viewedSeason === CUR_SEASON ? new Date() : earliest}
-        showCurrentTimeIndicator={viewedSeason === CUR_SEASON}
+        getNow={() => (viewedSeason === CUR_SEASON ? new Date() : new Date(0))}
         selected={selectedEvent}
         onSelectEvent={handleSelectEvent}
         components={calendarComponents}

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -379,6 +379,7 @@ function WorksheetCalendar({
         max={latest}
         localizer={localizer}
         toolbar={false}
+        scrollToTime={viewedSeason === CUR_SEASON ? new Date() : earliest}
         showCurrentTimeIndicator={viewedSeason === CUR_SEASON}
         selected={selectedEvent}
         onSelectEvent={handleSelectEvent}

--- a/frontend/src/components/Worksheet/WorksheetCalendar.tsx
+++ b/frontend/src/components/Worksheet/WorksheetCalendar.tsx
@@ -18,6 +18,7 @@ import {
   ColorPickerModal,
   WorksheetMoveModal,
 } from './WorksheetItemActionsButton';
+import { CUR_SEASON } from '../../config';
 import { useStore } from '../../store';
 import {
   localizer,
@@ -378,7 +379,7 @@ function WorksheetCalendar({
         max={latest}
         localizer={localizer}
         toolbar={false}
-        showCurrentTimeIndicator
+        showCurrentTimeIndicator={viewedSeason === CUR_SEASON}
         selected={selectedEvent}
         onSelectEvent={handleSelectEvent}
         components={calendarComponents}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -8,8 +8,11 @@ export const GRAPHQL_API_ENDPOINT = isDev
   ? 'https://localhost:8085'
   : `${import.meta.env.VITE_API_ENDPOINT}/ferry`;
 
+// The season we're actually in (used for time indicator, etc.)
+export const CUR_SEASON = '202601' as Season;
+
 // Used for which season to show by default in catalog and worksheet
-export const CUR_SEASON = '202603' as Season;
+export const DEFAULT_SEASON = '202603' as Season;
 
 // Courses in the current year have no evaluations yet. Also: if both the
 // listing and the API "latest" term are in this set, we skip the worksheet

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-bootstrap';
 import { FaChevronRight } from 'react-icons/fa';
 import { TextComponent } from '../components/Typography';
-import { API_ENDPOINT, CUR_SEASON } from '../config';
+import { API_ENDPOINT, DEFAULT_SEASON } from '../config';
 import { scrollToTop } from '../utilities/display';
 import styles from './FAQ.module.css';
 
@@ -404,28 +404,28 @@ const faqs = [
               <li>
                 For <b>public data</b> in JSON format: go to{' '}
                 <a
-                  href={`${API_ENDPOINT}/api/catalog/public/${CUR_SEASON}`}
+                  href={`${API_ENDPOINT}/api/catalog/public/${DEFAULT_SEASON}`}
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  {API_ENDPOINT}/api/catalog/public/{CUR_SEASON}
+                  {API_ENDPOINT}/api/catalog/public/{DEFAULT_SEASON}
                 </a>
-                . Replace {CUR_SEASON} with the season code you want (four-digit
-                year + two-digit season, 01 = spring, 02 = summer, 03 = fall).
-                Press <kbd>Ctrl</kbd> + <kbd>S</kbd> to save the data to a local
-                file.
+                . Replace {DEFAULT_SEASON} with the season code you want
+                (four-digit year + two-digit season, 01 = spring, 02 = summer,
+                03 = fall). Press <kbd>Ctrl</kbd> + <kbd>S</kbd> to save the
+                data to a local file.
               </li>
               <li>
                 For <b>evaluations data</b> in JSON format: go to{' '}
                 <a
-                  href={`${API_ENDPOINT}/api/catalog/evals/${CUR_SEASON}`}
+                  href={`${API_ENDPOINT}/api/catalog/evals/${DEFAULT_SEASON}`}
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  {API_ENDPOINT}/api/catalog/evals/{CUR_SEASON}
+                  {API_ENDPOINT}/api/catalog/evals/{DEFAULT_SEASON}
                 </a>
-                . Replace {CUR_SEASON} with the season code you want. (This URL
-                likely doesn't work because the current season doesn't have
+                . Replace {DEFAULT_SEASON} with the season code you want. (This
+                URL likely doesn't work because the current season doesn't have
                 evaluations yet.) Press <kbd>Ctrl</kbd> + <kbd>S</kbd> to save
                 the data to a local file. Note that you must be signed in on
                 CourseTable to access this data.
@@ -433,14 +433,14 @@ const faqs = [
               <li>
                 For <b>all data</b> in CSV format: go to{' '}
                 <a
-                  href={`${API_ENDPOINT}/api/catalog/csv/${CUR_SEASON}.csv`}
+                  href={`${API_ENDPOINT}/api/catalog/csv/${DEFAULT_SEASON}.csv`}
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  {API_ENDPOINT}/api/catalog/csv/{CUR_SEASON}.csv
+                  {API_ENDPOINT}/api/catalog/csv/{DEFAULT_SEASON}.csv
                 </a>
-                . Replace {CUR_SEASON} with the season code you want. The CSV
-                should be automatically downloaded.
+                . Replace {DEFAULT_SEASON} with the season code you want. The
+                CSV should be automatically downloaded.
               </li>
             </ul>
           </>

--- a/frontend/src/pages/Graphiql.tsx
+++ b/frontend/src/pages/Graphiql.tsx
@@ -2,7 +2,7 @@ import { createGraphiQLFetcher } from '@graphiql/toolkit';
 import GraphiQL from 'graphiql';
 import 'graphiql/graphiql.css';
 
-import { CUR_SEASON, GRAPHQL_API_ENDPOINT } from '../config';
+import { DEFAULT_SEASON, GRAPHQL_API_ENDPOINT } from '../config';
 
 // GraphiQL expects fetch.preconnect for subscription setup; we use HTTP-only
 const graphiqlFetch = Object.assign(
@@ -34,7 +34,7 @@ function Graphiql() {
       <GraphiQL
         fetcher={fetcher}
         defaultQuery={`{
-  courses(where: { season_code: { _eq: "${CUR_SEASON}" } }) {
+  courses(where: { season_code: { _eq: "${DEFAULT_SEASON}" } }) {
     title
     credits
     # Get information about the course's meetings

--- a/frontend/src/search/searchConstants.ts
+++ b/frontend/src/search/searchConstants.ts
@@ -1,5 +1,5 @@
 import { type Filters, type Option, sortByOptions } from './searchTypes';
-import { CUR_SEASON } from '../config';
+import { DEFAULT_SEASON } from '../config';
 import buildingsData from '../generated/buildings.json';
 import type { Buildings } from '../generated/graphql-types';
 import seasonsData from '../generated/seasons.json';
@@ -99,7 +99,9 @@ export const defaultFilters: Filters = {
   overallBounds: [1, 5],
   workloadBounds: [1, 5],
   professorBounds: [1, 5],
-  selectSeasons: [{ value: CUR_SEASON, label: toSeasonString(CUR_SEASON) }],
+  selectSeasons: [
+    { value: DEFAULT_SEASON, label: toSeasonString(DEFAULT_SEASON) },
+  ],
   selectDays: [],
   timeBounds: [toRangeTime('7:00'), toRangeTime('22:00')],
   enrollBounds: [1, 528],

--- a/frontend/src/slices/WorksheetSlice.ts
+++ b/frontend/src/slices/WorksheetSlice.ts
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 import type { StateCreator } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { CUR_SEASON } from '../config';
+import { DEFAULT_SEASON } from '../config';
 import { seasons as allSeasons } from '../data/catalogSeasons';
 import { useWorksheetInfo } from '../hooks/useFerry';
 import type { UserWorksheets } from '../queries/api';
@@ -152,7 +152,7 @@ export const createWorksheetSlice: StateCreator<
   WorksheetSlice
 > = (set, get) => ({
   viewedPerson: 'me',
-  viewedSeason: CUR_SEASON,
+  viewedSeason: DEFAULT_SEASON,
   viewedWorksheetNumber: 0,
   changeViewedPerson(newPerson) {
     set({ viewedWorksheetNumber: 0, viewedPerson: newPerson });


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have searched for potential duplicate pull requests.
- [x] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

In profile.handlers.ts:344, when the query contains a space, the search now splits it into first and last tokens and builds cross-field AND conditions — matching users where a first-name field contains first AND a last-name field contains last, or the reverse order (last-first input). Single-word queries behave exactly as before. 

Fixes #1964 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile search enhanced to support multi-word name queries with separate first and last name matching, improving search precision.

* **Improvements**
  * Calendar time positioning now adjusts based on the season being viewed, displaying appropriate time indicators for current and non-current seasons.
  * Default season configuration updated across the application for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->