### PR TITLE
fixed first and last name handling with spaces

### DIFF
--- a/api/src/profile/profile.handlers.ts
+++ b/api/src/profile/profile.handlers.ts
@@ -4,6 +4,7 @@ import z from 'zod';
 
 import {
   canViewerSee,
+  escapeLike,
   getSelfDisplayNames,
   getVisibleDisplayName,
   normalizePrivacySettings,
@@ -330,6 +331,54 @@ export const revokeEvaluationsAccess = async (
   res.status(200).json({ hasEvals: false, evalsRevoked: true });
 };
 
+// Builds a Drizzle WHERE condition for a name/netId search query.
+// Single-token queries match against netId and all name fields.
+// Multi-token queries try all pairwise (token_i, token_j) combinations as
+// (first-name field, last-name field), covering first-last, last-first, and
+// compound names like "Mary Jo Smith". NetId is excluded from multi-token
+// matching — netIds are alphanumeric and cannot contain spaces.
+const buildNameCondition = (q: string) => {
+  // Deduplicate and cap at 4 tokens to bound pairwise combinations (≤12).
+  const tokens = [
+    ...new Set(
+      q
+        .split(' ')
+        .map((t) => escapeLike(t))
+        .filter((t) => t.length > 0),
+    ),
+  ].slice(0, 4) as [string, ...string[]];
+
+  if (tokens.length === 1) {
+    const [t] = tokens;
+    return or(
+      ilike(studentBluebookSettings.netId, `%${t}%`),
+      ilike(studentBluebookSettings.firstName, `%${t}%`),
+      ilike(studentBluebookSettings.lastName, `%${t}%`),
+      ilike(studentBluebookSettings.preferredFirstName, `%${t}%`),
+      ilike(studentBluebookSettings.preferredLastName, `%${t}%`),
+    );
+  }
+
+  const pairs = tokens.flatMap((first, i) =>
+    tokens
+      .filter((_, j) => j !== i)
+      .map((last) =>
+        and(
+          or(
+            ilike(studentBluebookSettings.firstName, `%${first}%`),
+            ilike(studentBluebookSettings.preferredFirstName, `%${first}%`),
+          ),
+          or(
+            ilike(studentBluebookSettings.lastName, `%${last}%`),
+            ilike(studentBluebookSettings.preferredLastName, `%${last}%`),
+          ),
+        ),
+      ),
+  );
+
+  return or(...pairs);
+};
+
 export const searchProfiles = async (
   req: express.Request,
   res: express.Response,
@@ -343,41 +392,7 @@ export const searchProfiles = async (
 
   const { q, limit } = queryParse.data;
 
-  const spaceIdx = q.indexOf(' ');
-  const nameCondition =
-    spaceIdx === -1
-      ? or(
-          ilike(studentBluebookSettings.netId, `%${q}%`),
-          ilike(studentBluebookSettings.firstName, `%${q}%`),
-          ilike(studentBluebookSettings.lastName, `%${q}%`),
-          ilike(studentBluebookSettings.preferredFirstName, `%${q}%`),
-          ilike(studentBluebookSettings.preferredLastName, `%${q}%`),
-        )
-      : (() => {
-          const first = q.slice(0, spaceIdx);
-          const last = q.slice(spaceIdx + 1);
-          const firstFields = or(
-            ilike(studentBluebookSettings.firstName, `%${first}%`),
-            ilike(studentBluebookSettings.preferredFirstName, `%${first}%`),
-          );
-          const lastFields = or(
-            ilike(studentBluebookSettings.lastName, `%${last}%`),
-            ilike(studentBluebookSettings.preferredLastName, `%${last}%`),
-          );
-          // Also try last-first order
-          const lastFirstFields = or(
-            ilike(studentBluebookSettings.lastName, `%${first}%`),
-            ilike(studentBluebookSettings.preferredLastName, `%${first}%`),
-          );
-          const firstLastFields = or(
-            ilike(studentBluebookSettings.firstName, `%${last}%`),
-            ilike(studentBluebookSettings.preferredFirstName, `%${last}%`),
-          );
-          return or(
-            and(firstFields, lastFields),
-            and(lastFirstFields, firstLastFields),
-          );
-        })();
+  const nameCondition = buildNameCondition(q);
 
   const candidates = (await db.query.studentBluebookSettings.findMany({
     where: and(

--- a/api/src/profile/profile.handlers.ts
+++ b/api/src/profile/profile.handlers.ts
@@ -343,16 +343,46 @@ export const searchProfiles = async (
 
   const { q, limit } = queryParse.data;
 
+  const spaceIdx = q.indexOf(' ');
+  const nameCondition =
+    spaceIdx === -1
+      ? or(
+          ilike(studentBluebookSettings.netId, `%${q}%`),
+          ilike(studentBluebookSettings.firstName, `%${q}%`),
+          ilike(studentBluebookSettings.lastName, `%${q}%`),
+          ilike(studentBluebookSettings.preferredFirstName, `%${q}%`),
+          ilike(studentBluebookSettings.preferredLastName, `%${q}%`),
+        )
+      : (() => {
+          const first = q.slice(0, spaceIdx);
+          const last = q.slice(spaceIdx + 1);
+          const firstFields = or(
+            ilike(studentBluebookSettings.firstName, `%${first}%`),
+            ilike(studentBluebookSettings.preferredFirstName, `%${first}%`),
+          );
+          const lastFields = or(
+            ilike(studentBluebookSettings.lastName, `%${last}%`),
+            ilike(studentBluebookSettings.preferredLastName, `%${last}%`),
+          );
+          // Also try last-first order
+          const lastFirstFields = or(
+            ilike(studentBluebookSettings.lastName, `%${first}%`),
+            ilike(studentBluebookSettings.preferredLastName, `%${first}%`),
+          );
+          const firstLastFields = or(
+            ilike(studentBluebookSettings.firstName, `%${last}%`),
+            ilike(studentBluebookSettings.preferredFirstName, `%${last}%`),
+          );
+          return or(
+            and(firstFields, lastFields),
+            and(lastFirstFields, firstLastFields),
+          );
+        })();
+
   const candidates = (await db.query.studentBluebookSettings.findMany({
     where: and(
       eq(studentBluebookSettings.profilePageEnabled, true),
-      or(
-        ilike(studentBluebookSettings.netId, `%${q}%`),
-        ilike(studentBluebookSettings.firstName, `%${q}%`),
-        ilike(studentBluebookSettings.lastName, `%${q}%`),
-        ilike(studentBluebookSettings.preferredFirstName, `%${q}%`),
-        ilike(studentBluebookSettings.preferredLastName, `%${q}%`),
-      ),
+      nameCondition,
     ),
     columns: profileColumns,
     limit,

--- a/api/src/profile/profile.utils.ts
+++ b/api/src/profile/profile.utils.ts
@@ -128,6 +128,8 @@ export const getSelfDisplayNames = (names: ProfileNames) => {
   };
 };
 
+export const escapeLike = (s: string): string => s.replace(/[%_\\]/gu, '\\$&');
+
 export const sanitizeNullableName = (
   value: unknown,
 ): string | null | undefined => {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have searched for potential duplicate pull requests.
- [x] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

In profile.handlers.ts:344, when the query contains a space, the search now splits it into first and last tokens and builds cross-field AND conditions — matching users where a first-name field contains first AND a last-name field contains last, or the reverse order (last-first input). Single-word queries behave exactly as before. 

Fixes #1964 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved profile search accuracy and performance when handling multi-word queries and special characters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->