### PR TITLE
chore: 202602 eval release

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -14,7 +14,7 @@ export const CUR_SEASON = '202603' as Season;
 // Courses in the current year have no evaluations yet. Also: if both the
 // listing and the API "latest" term are in this set, we skip the worksheet
 // "add latest offering?" modal (avoids false "past semester" across that window).
-export const CUR_YEAR = ['202601', '202602', '202603', '202701'] as Season[];
+export const CUR_YEAR = ['202601', '202603', '202701'] as Season[];
 
 // We use this format to avoid dealing with time zones.
 // TODO: this should be a Temporal.PlainDate


### PR DESCRIPTION
## Summary
- Remove `202602` from `CUR_YEAR` so Spring 2026 evaluations are shown in the UI

## Depends on
- [Ferry Manual Evals Release dry run](https://github.com/coursetable/ferry/actions/runs/26853590490) completing successfully
- Prod eval sync (`sync_db: true`) after dry run review

## Test plan
- [ ] After Ferry prod sync, open a Spring 2026 course with eval access and confirm Evaluations tab works
- [ ] Confirm "Open in OCE" appears for 202602 courses


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated season configuration to reflect current active periods. Removed one season identifier from the list of seasons designated for the current year cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->