### PR TITLE
chore: 202601 eval release

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -14,7 +14,7 @@ export const CUR_SEASON = '202603' as Season;
 // Courses in the current year have no evaluations yet. Also: if both the
 // listing and the API "latest" term are in this set, we skip the worksheet
 // "add latest offering?" modal (avoids false "past semester" across that window).
-export const CUR_YEAR = ['202601', '202602', '202603', '202701'] as Season[];
+export const CUR_YEAR = ['202602', '202603', '202701'] as Season[];
 
 // We use this format to avoid dealing with time zones.
 // TODO: this should be a Temporal.PlainDate


### PR DESCRIPTION
Remove Spring 2026 from CUR_YEAR now that Ferry eval sync is live.

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

The template can be skipped for small and straightforward changes, such as typo fixes.
-->

## Pre-flight checklist

- [ ] I have searched for potential duplicate pull requests.
- [ ] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

This PR fixes/implements the following **bugs/features**

- Bug 1
- Bug 2
- Feature 1
- Feature 2
- Breaking changes

## Test plan (required)

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

## Related issues/PRs

<!-- Put `fixes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the current time period configuration to include the latest available seasons. This ensures the application displays the most recent and relevant information across all features that depend on current seasonal data. The changes maintain consistency and accuracy throughout the platform while keeping users informed with the latest available content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->