### PR TITLE
fix: restrict Hasura proxy to GraphQL

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "test": "node --no-deprecation --import tsx --test src/ferry/ferry.routes.test.ts",
     "prestart": "npm run codegen",
     "start": "npm run codegen:format && tsx watch src/server.ts",
     "start:prod": "tsx src/server.ts",

--- a/api/src/ferry/ferry.routes.test.ts
+++ b/api/src/ferry/ferry.routes.test.ts
@@ -1,0 +1,433 @@
+import assert from 'node:assert/strict';
+import {
+  createServer,
+  request as httpRequest,
+  type IncomingHttpHeaders,
+  type OutgoingHttpHeaders,
+  type Server,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { after, before, beforeEach, describe, test } from 'node:test';
+import express from 'express';
+
+import { registerFerryProxy } from './ferry.routes.js';
+
+const TRUSTED_ADMIN_SECRET = 'trusted-test-admin-secret';
+
+const BLOCKED_FERRY_PATHS = [
+  '/ferry',
+  '/ferry/',
+  '/ferry/v1',
+  '/ferry/v1/metadata',
+  '/ferry/v2/query',
+  '/ferry/v1alpha1/pg_dump',
+  '/ferry/healthz',
+  '/ferry/v1/version',
+  '/ferry/v1/graphql/',
+  '/ferry/v1/graphql/explain',
+  '/ferry/v1/graphql.admin',
+  '/ferry/v1/graphql;admin',
+  '/FERRY/V1/GRAPHQL',
+  '/ferry//v1/graphql',
+  '/ferry/v1/graphql/../metadata',
+  '/ferry/v1/%67raphql',
+  '/ferry/v1%2fgraphql',
+  '/ferry/v1%5cgraphql',
+  '/ferry/v1/graphql%2f..%2fv1%2fmetadata',
+  '/ferry/v1/graphql%zz',
+  '/ferry\\v1\\graphql',
+  '/ferry/v1/graphql#fragment',
+  'http://example.test/ferry/v1/graphql',
+] as const;
+
+const BLOCKED_FERRY_METHODS = [
+  'HEAD',
+  'OPTIONS',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'TRACE',
+] as const;
+
+const FORBIDDEN_UPSTREAM_HEADERS = [
+  'expect',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'upgrade',
+  'x-remove-me',
+] as const;
+
+type HasuraHeaders = {
+  [header: string]: string | string[];
+};
+
+type CapturedRequest = Readonly<{
+  body: string;
+  connection: string;
+  hasuraHeaders: HasuraHeaders;
+  method: string;
+  path: string;
+  unsafeHeaders: HasuraHeaders;
+}>;
+
+type TestResponse = Readonly<{
+  body: string;
+  headers: IncomingHttpHeaders;
+  status: number;
+}>;
+
+type FerryFixture = Readonly<{
+  close: () => Promise<void>;
+  completedExpressHasuraHeaders: HasuraHeaders[];
+  origin: string;
+  reset: () => void;
+  setAuthenticated: (authenticated: boolean) => void;
+  upstreamRequests: CapturedRequest[];
+}>;
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error) => reject(error);
+    server.once('error', handleError);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', handleError);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function sendRequest(
+  origin: string,
+  path: string,
+  options: Readonly<{
+    body?: string;
+    headers?: OutgoingHttpHeaders;
+    method?: string;
+    waitForContinue?: boolean;
+  }> = {},
+): Promise<TestResponse> {
+  const url = new URL(origin);
+
+  return await new Promise<TestResponse>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        headers: options.headers,
+        hostname: url.hostname,
+        method: options.method ?? 'GET',
+        path,
+        port: url.port,
+        protocol: url.protocol,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk: Buffer) => chunks.push(chunk));
+        response.on('end', () => {
+          resolve({
+            body: Buffer.concat(chunks).toString('utf8'),
+            headers: response.headers,
+            status: response.statusCode ?? 0,
+          });
+        });
+      },
+    );
+
+    request.on('error', reject);
+    const sendBody = () => {
+      if (options.body !== undefined) request.write(options.body);
+      request.end();
+    };
+    if (options.waitForContinue) {
+      request.once('continue', sendBody);
+      request.flushHeaders();
+    } else {
+      sendBody();
+    }
+  });
+}
+
+async function createFerryFixture(): Promise<FerryFixture> {
+  const completedExpressHasuraHeaders: HasuraHeaders[] = [];
+  const upstreamRequests: CapturedRequest[] = [];
+  let authenticated = false;
+
+  const upstream = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk: Buffer) => chunks.push(chunk));
+    request.on('end', () => {
+      const hasuraHeaders: HasuraHeaders = {};
+      for (const [name, value] of Object.entries(request.headers)) {
+        if (name.startsWith('x-hasura-') && value !== undefined)
+          hasuraHeaders[name] = value;
+      }
+      const unsafeHeaders: HasuraHeaders = {};
+      for (const name of FORBIDDEN_UPSTREAM_HEADERS) {
+        const value = request.headers[name];
+        if (value !== undefined) unsafeHeaders[name] = value;
+      }
+
+      const capturedRequest: CapturedRequest = {
+        body: Buffer.concat(chunks).toString('utf8'),
+        connection: request.headers.connection ?? '',
+        hasuraHeaders,
+        method: request.method ?? '',
+        path: request.url ?? '',
+        unsafeHeaders,
+      };
+      upstreamRequests.push(capturedRequest);
+
+      response.statusCode = 200;
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify(capturedRequest));
+    });
+  });
+  const upstreamOrigin = await listen(upstream);
+
+  const app = express();
+  app.use((request, response, next) => {
+    response.on('finish', () => {
+      const hasuraHeaders: HasuraHeaders = {};
+      for (const [name, value] of Object.entries(request.headers)) {
+        if (name.startsWith('x-hasura-') && value !== undefined)
+          hasuraHeaders[name] = value;
+      }
+      completedExpressHasuraHeaders.push(hasuraHeaders);
+    });
+    next();
+  });
+  app.use((request, _response, next) => {
+    request.isAuthenticated =
+      function isAuthenticated(): this is Express.AuthenticatedRequest {
+        return authenticated;
+      };
+    next();
+  });
+  registerFerryProxy(app, {
+    adminSecret: TRUSTED_ADMIN_SECRET,
+    target: upstreamOrigin,
+  });
+  // Mirror production middleware order so body-parser regressions are visible.
+  app.use(express.urlencoded({ extended: true }));
+  app.use((_request, response) => {
+    response.status(404).json({ error: 'NOT_FOUND' });
+  });
+
+  const api = createServer(app);
+  const origin = await listen(api);
+
+  return {
+    async close() {
+      await close(api);
+      await close(upstream);
+    },
+    completedExpressHasuraHeaders,
+    origin,
+    reset() {
+      authenticated = false;
+      completedExpressHasuraHeaders.length = 0;
+      upstreamRequests.length = 0;
+    },
+    setAuthenticated(value) {
+      authenticated = value;
+    },
+    upstreamRequests,
+  };
+}
+
+void describe('Ferry proxy', () => {
+  // Initialized by the suite's `before` hook.
+  // eslint-disable-next-line init-declarations
+  let fixture: FerryFixture;
+
+  before(async () => {
+    fixture = await createFerryFixture();
+  });
+
+  beforeEach(() => fixture.reset());
+
+  after(async () => {
+    await fixture.close();
+  });
+
+  void test('forwards an anonymous GraphQL POST with its query string and body', async () => {
+    const body = JSON.stringify({ query: 'query Catalog { seasons }' });
+
+    const response = await sendRequest(
+      fixture.origin,
+      '/ferry/v1/graphql?operation=Catalog',
+      {
+        body,
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      },
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(fixture.upstreamRequests, [
+      {
+        body,
+        connection: 'close',
+        hasuraHeaders: {
+          'x-hasura-admin-secret': TRUSTED_ADMIN_SECRET,
+          'x-hasura-role': 'anonymous',
+        },
+        method: 'POST',
+        path: '/v1/graphql?operation=Catalog',
+        unsafeHeaders: {},
+      },
+    ]);
+  });
+
+  void test('forwards an authenticated GraphQL GET with the student role', async () => {
+    fixture.setAuthenticated(true);
+
+    const response = await sendRequest(
+      fixture.origin,
+      '/ferry/v1/graphql?query=query%20Catalog%20%7B%20seasons%20%7D',
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(fixture.upstreamRequests, [
+      {
+        body: '',
+        connection: 'close',
+        hasuraHeaders: {
+          'x-hasura-admin-secret': TRUSTED_ADMIN_SECRET,
+          'x-hasura-role': 'student',
+        },
+        method: 'GET',
+        path: '/v1/graphql?query=query%20Catalog%20%7B%20seasons%20%7D',
+        unsafeHeaders: {},
+      },
+    ]);
+  });
+
+  void test('injects trusted headers before forwarding Expect: 100-continue', async () => {
+    const body = JSON.stringify({ query: 'mutation Test { test }' });
+
+    const response = await sendRequest(fixture.origin, '/ferry/v1/graphql', {
+      body,
+      headers: {
+        'content-type': 'application/json',
+        Expect: '100-continue',
+      },
+      method: 'POST',
+      waitForContinue: true,
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(fixture.upstreamRequests, [
+      {
+        body,
+        connection: 'close',
+        hasuraHeaders: {
+          'x-hasura-admin-secret': TRUSTED_ADMIN_SECRET,
+          'x-hasura-role': 'anonymous',
+        },
+        method: 'POST',
+        path: '/v1/graphql',
+        unsafeHeaders: {},
+      },
+    ]);
+  });
+
+  void test('streams URL-encoded GraphQL bodies without consuming them', async () => {
+    const body = 'query=mutation%20Test%20%7B%20test%20%7D';
+
+    const response = await sendRequest(fixture.origin, '/ferry/v1/graphql', {
+      body,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      method: 'POST',
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(fixture.upstreamRequests, [
+      {
+        body,
+        connection: 'close',
+        hasuraHeaders: {
+          'x-hasura-admin-secret': TRUSTED_ADMIN_SECRET,
+          'x-hasura-role': 'anonymous',
+        },
+        method: 'POST',
+        path: '/v1/graphql',
+        unsafeHeaders: {},
+      },
+    ]);
+  });
+
+  for (const path of BLOCKED_FERRY_PATHS) {
+    void test(`rejects non-GraphQL raw path ${JSON.stringify(path)}`, async () => {
+      const response = await sendRequest(fixture.origin, path);
+
+      assert.equal(response.status, 404);
+      assert.equal(fixture.upstreamRequests.length, 0);
+    });
+  }
+
+  for (const method of BLOCKED_FERRY_METHODS) {
+    void test(`rejects unsupported GraphQL method ${method}`, async () => {
+      const response = await sendRequest(fixture.origin, '/ferry/v1/graphql', {
+        method,
+      });
+
+      assert.equal(response.status, 405);
+      assert.equal(response.headers.allow, 'GET, POST');
+      assert.equal(fixture.upstreamRequests.length, 0);
+    });
+  }
+
+  void test('replaces all client Hasura headers only on the outbound request', async () => {
+    const body = 'test';
+    const response = await sendRequest(fixture.origin, '/ferry/v1/graphql', {
+      body,
+      headers: {
+        Connection: 'upgrade, x-hasura-role, x-remove-me',
+        'Keep-Alive': 'timeout=5',
+        'Proxy-Authenticate': 'Basic client-controlled',
+        'Proxy-Authorization': 'Basic client-controlled',
+        TE: 'trailers',
+        Trailer: 'X-Checksum',
+        'X-Hasura-Access-Key': 'legacy-client-secret',
+        'X-Hasura-Admin-Secret': ['client-secret-one', 'client-secret-two'],
+        'X-Hasura-Allowed-Roles': 'admin, student',
+        'X-Hasura-Custom-Session': 'client-controlled',
+        'X-Hasura-Role': ['admin', 'superuser'],
+        'X-Hasura-Use-Backend-Only-Permissions': 'true',
+        'X-Hasura-User-Id': 'victim',
+        'X-Remove-Me': 'client-controlled',
+      },
+      method: 'POST',
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(fixture.upstreamRequests, [
+      {
+        body,
+        connection: 'close',
+        hasuraHeaders: {
+          'x-hasura-admin-secret': TRUSTED_ADMIN_SECRET,
+          'x-hasura-role': 'anonymous',
+        },
+        method: 'POST',
+        path: '/v1/graphql',
+        unsafeHeaders: {},
+      },
+    ]);
+    assert.deepEqual(fixture.completedExpressHasuraHeaders, [{}]);
+  });
+});

--- a/api/src/ferry/ferry.routes.test.ts
+++ b/api/src/ferry/ferry.routes.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import {
   createServer,
   request as httpRequest,
@@ -247,6 +248,19 @@ async function createFerryFixture(): Promise<FerryFixture> {
     upstreamRequests,
   };
 }
+
+void test('registers request logging before the Ferry proxy', async () => {
+  const serverSource = await readFile(
+    new URL('../server.ts', import.meta.url),
+    'utf8',
+  );
+  const requestLoggingIndex = serverSource.indexOf('app.use(morgan);');
+  const ferryProxyIndex = serverSource.indexOf('registerFerryProxy(app,');
+
+  assert.notEqual(requestLoggingIndex, -1);
+  assert.notEqual(ferryProxyIndex, -1);
+  assert.ok(requestLoggingIndex < ferryProxyIndex);
+});
 
 void describe('Ferry proxy', () => {
   // Initialized by the suite's `before` hook.

--- a/api/src/ferry/ferry.routes.ts
+++ b/api/src/ferry/ferry.routes.ts
@@ -1,0 +1,83 @@
+import type { Application, Request, Response } from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+
+const DEFAULT_FERRY_TARGET = 'http://graphql-engine:8080';
+const FERRY_GRAPHQL_PATH = '/ferry/v1/graphql';
+const FERRY_GRAPHQL_METHODS = new Set(['GET', 'POST']);
+const HOP_BY_HOP_HEADERS = [
+  'connection',
+  'expect',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+] as const;
+
+export type FerryProxyOptions = Readonly<{
+  adminSecret: string;
+  target?: string;
+}>;
+
+export function registerFerryProxy(
+  app: Application,
+  options: FerryProxyOptions,
+): void {
+  app.use(
+    '/ferry',
+    (request, response, next) => {
+      const queryIndex = request.originalUrl.indexOf('?');
+      const rawPath =
+        queryIndex === -1
+          ? request.originalUrl
+          : request.originalUrl.slice(0, queryIndex);
+      if (rawPath !== FERRY_GRAPHQL_PATH) {
+        response.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      if (!FERRY_GRAPHQL_METHODS.has(request.method)) {
+        response.set('Allow', 'GET, POST');
+        response.status(405).json({ error: 'METHOD_NOT_ALLOWED' });
+        return;
+      }
+
+      const hasuraHeaders = Object.keys(request.headers).filter((header) =>
+        header.startsWith('x-hasura-'),
+      );
+      for (const header of hasuraHeaders) delete request.headers[header];
+
+      const connectionHeaders = (request.headers.connection ?? '')
+        .split(',')
+        .map((header) => header.trim().toLowerCase())
+        .filter(Boolean);
+      const hopByHopHeaders = new Set([
+        ...HOP_BY_HOP_HEADERS,
+        ...connectionHeaders,
+      ]);
+      for (const header of hopByHopHeaders) delete request.headers[header];
+      next();
+    },
+    createProxyMiddleware<Request, Response>({
+      on: {
+        proxyReq(proxyRequest, request) {
+          const hasuraHeaders = proxyRequest
+            .getHeaderNames()
+            .filter((header) => header.startsWith('x-hasura-'));
+          for (const header of hasuraHeaders) proxyRequest.removeHeader(header);
+
+          const hasuraRole = request.isAuthenticated()
+            ? 'student'
+            : 'anonymous';
+          proxyRequest.setHeader('connection', 'close');
+          proxyRequest.setHeader('x-hasura-role', hasuraRole);
+          proxyRequest.setHeader('x-hasura-admin-secret', options.adminSecret);
+        },
+      },
+      target: options.target ?? DEFAULT_FERRY_TARGET,
+      xfwd: true,
+    }),
+  );
+}

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -105,11 +105,11 @@ passportConfig(passport);
 app.use(passport.initialize());
 app.use(passport.authenticate('session'));
 
-// Proxy initial GraphQL requests to Ferry.
-registerFerryProxy(app, { adminSecret: HASURA_GRAPHQL_ADMIN_SECRET });
-
 // Enable request logging.
 app.use(morgan);
+
+// Proxy initial GraphQL requests to Ferry.
+registerFerryProxy(app, { adminSecret: HASURA_GRAPHQL_ADMIN_SECRET });
 
 // Body parsers have to go after Ferry because they consume the request stream
 // that the HTTP proxy forwards to Hasura.

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,7 +5,6 @@ import * as Sentry from '@sentry/node';
 import RedisStore from 'connect-redis';
 import cors from 'cors';
 import session from 'express-session';
-import { createProxyMiddleware } from 'http-proxy-middleware';
 import passport from 'passport';
 
 // Import this at the top before any user modules
@@ -28,6 +27,7 @@ import {
   NUM_SEASONS,
 } from './config.js';
 import demand from './demand/demand.routes.js';
+import { registerFerryProxy } from './ferry/ferry.routes.js';
 import friends from './friends/friends.routes.js';
 import linkPreview from './link-preview/link-preview.routes.js';
 import morgan from './logging/morgan.js';
@@ -41,9 +41,6 @@ const app = express();
 // Trust the proxy.
 // See https://expressjs.com/en/guide/behind-proxies.html.
 app.set('trust proxy', true);
-
-// Enable url-encoding
-app.use(express.urlencoded({ extended: true }));
 
 // Enable Cross-Origin Resource Sharing
 // (i.e. let the frontend call the API when it's on a different domain)
@@ -108,30 +105,15 @@ passportConfig(passport);
 app.use(passport.initialize());
 app.use(passport.authenticate('session'));
 
-// Add the authentication header to the request
-// Proxy initial HTTP requests to Ferry
-app.use(
-  '/ferry',
-  (req, res, next) => {
-    const hasuraRole = req.isAuthenticated() ? 'student' : 'anonymous';
-    // Important: all headers must be lowercase; otherwise it will not override
-    // existing headers on the request.
-    req.headers['x-hasura-role'] = hasuraRole;
-    req.headers['x-hasura-admin-secret'] = HASURA_GRAPHQL_ADMIN_SECRET;
-    next();
-  },
-  createProxyMiddleware({
-    target: 'http://graphql-engine:8080',
-    pathRewrite: { '^/ferry/': '/' },
-    xfwd: true,
-  }),
-);
+// Proxy initial GraphQL requests to Ferry.
+registerFerryProxy(app, { adminSecret: HASURA_GRAPHQL_ADMIN_SECRET });
 
 // Enable request logging.
 app.use(morgan);
 
-// Has to go after Ferry because it consumes the request body stream
-// and the http-proxy needs a stream to consume.
+// Body parsers have to go after Ferry because they consume the request stream
+// that the HTTP proxy forwards to Hasura.
+app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 
 // Activate catalog and CAS authentication

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "frontend"
   ],
   "scripts": {
-    "checks": "bun run depcheck && bun run format:check && bun run lint:check && bun run lint:css:check && bun run resize-image:check && bun run typecheck && bun run --cwd frontend test",
+    "checks": "bun run depcheck && bun run format:check && bun run lint:check && bun run lint:css:check && bun run resize-image:check && bun run typecheck && bun run --cwd api test && bun run --cwd frontend test",
     "checks:fix": "bun run format && bun run lint && bun run lint:css && bun run resize-image",
     "typecheck": "tsc && tsc -p frontend && tsc -p api",
     "depcheck": "bunx depcheck . --ignore-patterns=api,frontend && bunx depcheck api && bunx depcheck frontend",


### PR DESCRIPTION
> [!CAUTION]
> **Critical security fix — prioritize review, merge, and deployment.**
>
> The current public `/ferry/*` proxy can forward unauthenticated requests to non-GraphQL Hasura administrative endpoints while attaching the server-held Hasura admin secret. Until this patch is deployed, an attacker may be able to perform privileged Hasura operations, including reading or modifying data and metadata or disrupting service.

## What changed

- restrict the public `/ferry` proxy to the exact `/ferry/v1/graphql` path and `GET`/`POST` methods
- reject alternate paths and methods before they can reach Hasura
- remove client-supplied Hasura, connection-nominated, and hop-by-hop headers before adding trusted outbound credentials
- preserve streamed JSON and URL-encoded request bodies
- register request logging before the Ferry proxy so Ferry responses reach the configured logger
- add regression coverage to the project checks

## Root cause and impact

The broad `/ferry` mount forwarded every descendant Hasura path while attaching the server-held admin secret. This made administrative Hasura endpoints reachable through a public API boundary, creating a risk of unauthorized data access or modification, metadata changes, and service disruption.

The fix closes that boundary while preserving the frontend GraphQL endpoint and its existing anonymous/student role behavior.

## Validation

- `bun run --cwd api test` — 35 tests passed
- `bun run typecheck`
- targeted ESLint — 0 errors
- Prettier and `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GraphQL ferry proxying with support for authenticated and anonymous requests.
  * Restricted ferry access to the supported GraphQL endpoint and GET/POST methods.
  * Added trusted header handling for secure upstream requests.

* **Bug Fixes**
  * Prevented client-supplied Hasura headers from being forwarded.
  * Improved handling of streamed and URL-encoded GraphQL requests.

* **Tests**
  * Added end-to-end coverage for proxying, validation, headers, and error responses.
  * Expanded project checks to include API tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->