### PR TITLE
feat: crosspost "How CourseTable Survives Shopping Period" to /releases

### DIFF
--- a/frontend/public/images/release_notes/shopping-period/architecture.svg
+++ b/frontend/public/images/release_notes/shopping-period/architecture.svg
@@ -1,0 +1,78 @@
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <defs>
+    <marker id="arrOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#E58A3C"/>
+    </marker>
+    <marker id="arrBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#4A7BB5"/>
+    </marker>
+    <marker id="arrGray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#999999"/>
+    </marker>
+  </defs>
+
+  <!-- Browser -->
+  <rect x="22" y="78" width="118" height="114" rx="8" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="81" y="100" text-anchor="middle" font-size="13" font-weight="600" fill="#333">Browser</text>
+  <text x="81" y="122" text-anchor="middle" font-size="11" fill="#666">catalog + search</text>
+  <text x="81" y="137" text-anchor="middle" font-size="11" fill="#666">(all client-side)</text>
+  <text x="81" y="163" text-anchor="middle" font-size="11" fill="#666">course modals,</text>
+  <text x="81" y="177" text-anchor="middle" font-size="11" fill="#666">worksheets</text>
+
+  <!-- Express API box -->
+  <rect x="262" y="52" width="170" height="160" rx="8" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="347" y="72" text-anchor="middle" font-size="13" font-weight="600" fill="#333">API server (Express)</text>
+  <!-- static files sub-box, vertically centered on hot path y=107 -->
+  <rect x="276" y="84" width="142" height="46" rx="6" fill="#E58A3C" fill-opacity="0.12" stroke="#E58A3C" stroke-width="1.3"/>
+  <text x="347" y="103" text-anchor="middle" font-size="11.5" font-weight="600" fill="#B05E1C">static catalog JSON</text>
+  <text x="347" y="119" text-anchor="middle" font-size="10.5" fill="#B05E1C">one file per semester</text>
+  <!-- proxy sub-box, vertically centered on live path y=169 -->
+  <rect x="276" y="146" width="142" height="46" rx="6" fill="#4A7BB5" fill-opacity="0.10" stroke="#4A7BB5" stroke-width="1.3"/>
+  <text x="347" y="165" text-anchor="middle" font-size="11.5" font-weight="600" fill="#2F5787">GraphQL proxy</text>
+  <text x="347" y="181" text-anchor="middle" font-size="10.5" fill="#2F5787">+ user data (auth, worksheets)</text>
+
+  <!-- Hasura: center y = 169, aligned with live path -->
+  <rect x="530" y="148" width="128" height="42" rx="8" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="594" y="174" text-anchor="middle" font-size="13" font-weight="600" fill="#333">Hasura</text>
+
+  <!-- Postgres -->
+  <rect x="530" y="226" width="128" height="42" rx="8" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="594" y="252" text-anchor="middle" font-size="13" font-weight="600" fill="#333">Postgres</text>
+
+  <!-- Ferry -->
+  <rect x="262" y="262" width="170" height="46" rx="8" fill="none" stroke="#999" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="347" y="282" text-anchor="middle" font-size="13" font-weight="600" fill="#666">Ferry crawler</text>
+  <text x="347" y="298" text-anchor="middle" font-size="10.5" fill="#888">nightly, GitHub Actions</text>
+
+  <!-- Yale APIs -->
+  <rect x="22" y="262" width="118" height="46" rx="8" fill="none" stroke="#999" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="81" y="282" text-anchor="middle" font-size="12.5" font-weight="600" fill="#666">Yale course</text>
+  <text x="81" y="298" text-anchor="middle" font-size="12.5" font-weight="600" fill="#666">&amp; eval APIs</text>
+
+  <!-- HOT PATH: browser edge (140) <-> API container edge (262), aligned to static sub-box center y=107 -->
+  <line x1="140" y1="107" x2="262" y2="107" stroke="#E58A3C" stroke-width="2.6" marker-end="url(#arrOrange)" marker-start="url(#arrOrange)"/>
+  <text x="201" y="96" text-anchor="middle" font-size="11" font-weight="600" fill="#B05E1C">hot path</text>
+  <text x="201" y="124" text-anchor="middle" font-size="10" fill="#B05E1C">GET 202601.json</text>
+  <text x="201" y="137" text-anchor="middle" font-size="10" fill="#B05E1C">cached for 1h</text>
+
+  <!-- LIVE PATH: browser edge (140) -> container edge (262), aligned to proxy sub-box center y=169 -->
+  <line x1="140" y1="169" x2="262" y2="169" stroke="#4A7BB5" stroke-width="2" marker-end="url(#arrBlue)"/>
+  <text x="201" y="160" text-anchor="middle" font-size="11" font-weight="600" fill="#2F5787">live path</text>
+  <!-- container edge (432) -> Hasura edge (530), horizontal at y=169 -->
+  <line x1="432" y1="169" x2="530" y2="169" stroke="#4A7BB5" stroke-width="2" marker-end="url(#arrBlue)"/>
+  <text x="481" y="160" text-anchor="middle" font-size="10" fill="#2F5787">GraphQL</text>
+  <!-- Hasura bottom (190) -> Postgres top (226), vertical at x=594 -->
+  <line x1="594" y1="190" x2="594" y2="226" stroke="#4A7BB5" stroke-width="2" marker-end="url(#arrBlue)"/>
+  <text x="602" y="212" font-size="10" fill="#2F5787">one SQL stmt</text>
+
+  <!-- OFFLINE: Yale edge (140) -> Ferry edge (262), horizontal at y=285 -->
+  <line x1="140" y1="285" x2="262" y2="285" stroke="#999" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#arrGray)"/>
+  <!-- Ferry corner -> Postgres left edge (530, y=253) -->
+  <line x1="432" y1="278" x2="530" y2="253" stroke="#999" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#arrGray)"/>
+  <text x="500" y="286" text-anchor="middle" font-size="10" fill="#888">writes courses</text>
+  <!-- Ferry top (262) -> container bottom edge (212), vertical at x=347 -->
+  <line x1="347" y1="262" x2="347" y2="212" stroke="#999" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#arrGray)"/>
+  <text x="355" y="242" font-size="10" fill="#888">/refresh &#8594; rewrite JSON</text>
+  <text x="201" y="301" text-anchor="middle" font-size="11" font-weight="600" fill="#888">offline, ~3 AM</text>
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/benchmark.svg
+++ b/frontend/public/images/release_notes/shopping-period/benchmark.svg
@@ -1,0 +1,58 @@
+<svg viewBox="0 0 680 340" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <!-- gridlines -->
+  <line x1="64" y1="86" x2="656" y2="86" stroke="#EEE" stroke-width="1"/>
+  <line x1="64" y1="16" x2="656" y2="16" stroke="#EEE" stroke-width="1"/>
+
+  <!-- 500 ms threshold (doubles as the 500 gridline) -->
+  <line x1="64" y1="226" x2="656" y2="226" stroke="#EEE" stroke-width="1"/>
+  <line x1="64" y1="156" x2="656" y2="156" stroke="#999" stroke-width="1.2" stroke-dasharray="6 4"/>
+  <text x="652" y="150" text-anchor="end" font-size="10" fill="#888">1 s</text>
+
+  <!-- axes -->
+  <line x1="64" y1="16" x2="64" y2="296" stroke="#444" stroke-width="1.2"/>
+  <line x1="64" y1="296" x2="656" y2="296" stroke="#444" stroke-width="1.2"/>
+
+  <!-- y tick labels -->
+  <text x="56" y="300" text-anchor="end" font-size="10" fill="#666">0</text>
+  <text x="56" y="230" text-anchor="end" font-size="10" fill="#666">500</text>
+  <text x="56" y="160" text-anchor="end" font-size="10" fill="#666">1000</text>
+  <text x="56" y="90" text-anchor="end" font-size="10" fill="#666">1500</text>
+  <text x="56" y="20" text-anchor="end" font-size="10" fill="#666">2000</text>
+  <text x="18" y="156" text-anchor="middle" font-size="11" fill="#333" transform="rotate(-90 18 156)">p99 latency (ms)</text>
+
+  <!-- x tick labels -->
+  <text x="64" y="312" text-anchor="middle" font-size="10" fill="#666">1</text>
+  <text x="283.3" y="312" text-anchor="middle" font-size="10" fill="#666">10</text>
+  <text x="436.6" y="312" text-anchor="middle" font-size="10" fill="#666">50</text>
+  <text x="502.6" y="312" text-anchor="middle" font-size="10" fill="#666">100</text>
+  <text x="590" y="312" text-anchor="middle" font-size="10" fill="#666">250</text>
+  <text x="656" y="312" text-anchor="middle" font-size="10" fill="#666">500</text>
+  <text x="360" y="332" text-anchor="middle" font-size="11" fill="#333">concurrent connections</text>
+
+  <!-- naive search API (trigram-indexed run) -->
+  <polyline points="64,293.3 283.3,291.1 436.6,264.1 502.6,262.3 590,205.6 656,34.3" fill="none" stroke="#4A7BB5" stroke-width="2.2"/>
+  <circle cx="64" cy="293.3" r="3.5" fill="#4A7BB5"/>
+  <circle cx="283.3" cy="291.1" r="3.5" fill="#4A7BB5"/>
+  <circle cx="436.6" cy="264.1" r="3.5" fill="#4A7BB5"/>
+  <circle cx="502.6" cy="262.3" r="3.5" fill="#4A7BB5"/>
+  <circle cx="590" cy="205.6" r="3.5" fill="#4A7BB5"/>
+  <circle cx="656" cy="34.3" r="3.5" fill="#4A7BB5"/>
+
+  <!-- static catalog (304 revalidation) -->
+  <polyline points="64,295.9 283.3,295.4 436.6,293.8 502.6,293.3 590,287.6 656,281.6" fill="none" stroke="#E58A3C" stroke-width="2.2"/>
+  <circle cx="64" cy="295.9" r="3.5" fill="#E58A3C"/>
+  <circle cx="283.3" cy="295.4" r="3.5" fill="#E58A3C"/>
+  <circle cx="436.6" cy="293.8" r="3.5" fill="#E58A3C"/>
+  <circle cx="502.6" cy="293.3" r="3.5" fill="#E58A3C"/>
+  <circle cx="590" cy="287.6" r="3.5" fill="#E58A3C"/>
+  <circle cx="656" cy="281.6" r="3.5" fill="#E58A3C"/>
+
+  <!-- legend -->
+  <line x1="84" y1="34" x2="112" y2="34" stroke="#4A7BB5" stroke-width="2.2"/>
+  <circle cx="98" cy="34" r="3" fill="#4A7BB5"/>
+  <text x="120" y="38" font-size="10.5" fill="#333">naive search API</text>
+  <line x1="84" y1="54" x2="112" y2="54" stroke="#E58A3C" stroke-width="2.2"/>
+  <circle cx="98" cy="54" r="3" fill="#E58A3C"/>
+  <text x="120" y="58" font-size="10.5" fill="#333">static catalog</text>
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/naive-search.svg
+++ b/frontend/public/images/release_notes/shopping-period/naive-search.svg
@@ -1,0 +1,38 @@
+<svg viewBox="0 0 640 220" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <defs>
+    <marker id="nArrBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#4A7BB5"/>
+    </marker>
+  </defs>
+
+  <!-- browsers: stacked cards -->
+  <rect x="42" y="52" width="110" height="80" rx="8" fill="#FFFFFF" fill-opacity="0" stroke="#BBB" stroke-width="1.3"/>
+  <rect x="35" y="58" width="110" height="80" rx="8" fill="#FFFFFF" fill-opacity="0" stroke="#888" stroke-width="1.3"/>
+  <rect x="28" y="64" width="110" height="80" rx="8" fill="#FDFDFC" stroke="#444" stroke-width="1.5"/>
+  <text x="83" y="98" text-anchor="middle" font-size="12.5" font-weight="600" fill="#333">Browsers</text>
+  <text x="83" y="118" text-anchor="middle" font-size="10.5" fill="#666">every student</text>
+
+  <!-- server -->
+  <rect x="260" y="74" width="110" height="60" rx="8" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="315" y="108" text-anchor="middle" font-size="12.5" font-weight="600" fill="#333">Server</text>
+
+  <!-- database -->
+  <rect x="480" y="74" width="110" height="60" rx="8" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="535" y="108" text-anchor="middle" font-size="12.5" font-weight="600" fill="#333">Database</text>
+
+  <!-- fan of keystroke requests: browser right edge (138) to server left edge (260) -->
+  <line x1="138" y1="86" x2="260" y2="92" stroke="#4A7BB5" stroke-width="1.6" marker-end="url(#nArrBlue)"/>
+  <line x1="138" y1="104" x2="260" y2="104" stroke="#4A7BB5" stroke-width="1.6" marker-end="url(#nArrBlue)"/>
+  <line x1="138" y1="122" x2="260" y2="116" stroke="#4A7BB5" stroke-width="1.6" marker-end="url(#nArrBlue)"/>
+  <text x="199" y="78" text-anchor="middle" font-size="9.5" font-family="ui-monospace, Menlo, monospace" fill="#2F5787">GET /search?q=&#8230;</text>
+  <text x="199" y="142" text-anchor="middle" font-size="10" fill="#666">per keystroke</text>
+
+  <!-- queries: server right edge (370) to database left edge (480) -->
+  <line x1="370" y1="96" x2="480" y2="96" stroke="#4A7BB5" stroke-width="1.6" marker-end="url(#nArrBlue)"/>
+  <line x1="370" y1="112" x2="480" y2="112" stroke="#4A7BB5" stroke-width="1.6" marker-end="url(#nArrBlue)"/>
+  <text x="425" y="86" text-anchor="middle" font-size="9.5" font-family="ui-monospace, Menlo, monospace" fill="#2F5787">SELECT &#8230; ILIKE</text>
+  <text x="425" y="142" text-anchor="middle" font-size="10" fill="#666">per request</text>
+
+  <text x="320" y="192" text-anchor="middle" font-size="11" font-weight="600" fill="#2F5787">the database sits on the hot path</text>
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/payload-rekeying.svg
+++ b/frontend/public/images/release_notes/shopping-period/payload-rekeying.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 680 204" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <defs>
+    <marker id="pArrOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#E58A3C"/>
+    </marker>
+  </defs>
+
+  <line x1="340" y1="16" x2="340" y2="192" stroke="#DDD" stroke-width="1.5"/>
+
+  <!-- LEFT: keyed by listing -->
+  <text x="170" y="32" text-anchor="middle" font-size="12.5" font-weight="600" fill="#333">Keyed by listing (before)</text>
+
+  <rect x="35" y="52" width="270" height="56" rx="7" fill="none" stroke="#444" stroke-width="1.4"/>
+  <text x="50" y="75" font-size="10.5" font-family="ui-monospace, Menlo, monospace" font-weight="600" fill="#333">"MATH 101":</text>
+  <text x="50" y="93" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#888">{ title, prof, ratings, &#8230; }</text>
+
+  <rect x="35" y="124" width="270" height="56" rx="7" fill="none" stroke="#444" stroke-width="1.4"/>
+  <text x="50" y="147" font-size="10.5" font-family="ui-monospace, Menlo, monospace" font-weight="600" fill="#333">"STAT 101":</text>
+  <text x="50" y="165" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#888">{ title, prof, ratings, &#8230; }</text>
+
+
+  <!-- RIGHT: keyed by course -->
+  <text x="510" y="32" text-anchor="middle" font-size="12.5" font-weight="600" fill="#333">Keyed by course (after)</text>
+
+  <rect x="400" y="52" width="220" height="54" rx="7" fill="#E58A3C" fill-opacity="0.12" stroke="#E58A3C" stroke-width="1.4"/>
+  <text x="415" y="74" font-size="10.5" font-family="ui-monospace, Menlo, monospace" font-weight="600" fill="#B05E1C">1234:</text>
+  <text x="415" y="92" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#B05E1C">{ title, prof, ratings, &#8230; }</text>
+
+  <rect x="365" y="156" width="130" height="34" rx="7" fill="none" stroke="#444" stroke-width="1.4"/>
+  <text x="430" y="177" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#333">"MATH 101"</text>
+  <rect x="525" y="156" width="130" height="34" rx="7" fill="none" stroke="#444" stroke-width="1.4"/>
+  <text x="590" y="177" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#333">"STAT 101"</text>
+
+  <line x1="430" y1="156" x2="480" y2="106" stroke="#E58A3C" stroke-width="1.8" marker-end="url(#pArrOrange)"/>
+  <line x1="590" y1="156" x2="540" y2="106" stroke="#E58A3C" stroke-width="1.8" marker-end="url(#pArrOrange)"/>
+  <text x="510" y="138" text-anchor="middle" font-size="10" fill="#B05E1C">by ID</text>
+
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/refresh-pipeline.svg
+++ b/frontend/public/images/release_notes/shopping-period/refresh-pipeline.svg
@@ -1,0 +1,36 @@
+<svg viewBox="0 0 680 130" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <defs>
+    <marker id="rArrGray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#999999"/>
+    </marker>
+  </defs>
+
+  <rect x="8" y="36" width="112" height="56" rx="7" fill="none" stroke="#999" stroke-width="1.4" stroke-dasharray="5 4"/>
+  <text x="64" y="60" text-anchor="middle" font-size="10.5" font-weight="600" fill="#666">GitHub Action</text>
+  <text x="64" y="76" text-anchor="middle" font-size="10" fill="#888">fires at ~3 AM</text>
+
+  <line x1="120" y1="64" x2="146" y2="64" stroke="#999" stroke-width="1.6" marker-end="url(#rArrGray)"/>
+
+  <rect x="146" y="36" width="112" height="56" rx="7" fill="none" stroke="#999" stroke-width="1.4" stroke-dasharray="5 4"/>
+  <text x="202" y="60" text-anchor="middle" font-size="10.5" font-weight="600" fill="#666">Ferry crawls</text>
+  <text x="202" y="76" text-anchor="middle" font-size="10" fill="#888">Yale's APIs</text>
+
+  <line x1="258" y1="64" x2="284" y2="64" stroke="#999" stroke-width="1.6" marker-end="url(#rArrGray)"/>
+
+  <rect x="284" y="36" width="112" height="56" rx="7" fill="none" stroke="#999" stroke-width="1.4" stroke-dasharray="5 4"/>
+  <text x="340" y="60" text-anchor="middle" font-size="10.5" font-weight="600" fill="#666">writes course</text>
+  <text x="340" y="76" text-anchor="middle" font-size="10" fill="#888">data to Postgres</text>
+
+  <line x1="396" y1="64" x2="422" y2="64" stroke="#999" stroke-width="1.6" marker-end="url(#rArrGray)"/>
+
+  <rect x="422" y="36" width="112" height="56" rx="7" fill="none" stroke="#999" stroke-width="1.4" stroke-dasharray="5 4"/>
+  <text x="478" y="60" text-anchor="middle" font-size="10.5" font-weight="600" fill="#666">pings /refresh with</text>
+  <text x="478" y="76" text-anchor="middle" font-size="10" fill="#888">changed semesters</text>
+
+  <line x1="534" y1="64" x2="560" y2="64" stroke="#999" stroke-width="1.6" marker-end="url(#rArrGray)"/>
+
+  <rect x="560" y="36" width="112" height="56" rx="7" fill="#E58A3C" fill-opacity="0.12" stroke="#E58A3C" stroke-width="1.4"/>
+  <text x="616" y="60" text-anchor="middle" font-size="10.5" font-weight="600" fill="#B05E1C">server rewrites</text>
+  <text x="616" y="76" text-anchor="middle" font-size="10" fill="#B05E1C">static files</text>
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/search-flow.svg
+++ b/frontend/public/images/release_notes/shopping-period/search-flow.svg
@@ -1,0 +1,44 @@
+<svg viewBox="0 0 640 296" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <defs>
+    <marker id="sArrOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#E58A3C"/>
+    </marker>
+    <marker id="sArrOrangeOpen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M1,1 L9,5 L1,9" fill="none" stroke="#E58A3C" stroke-width="1.6"/>
+    </marker>
+  </defs>
+
+  <!-- lifeline headers -->
+  <rect x="132" y="16" width="76" height="24" rx="6" fill="none" stroke="#444" stroke-width="1.4"/>
+  <text x="170" y="32" text-anchor="middle" font-size="11.5" font-weight="600" fill="#333">Browser</text>
+  <rect x="432" y="16" width="76" height="24" rx="6" fill="none" stroke="#444" stroke-width="1.4"/>
+  <text x="470" y="32" text-anchor="middle" font-size="11.5" font-weight="600" fill="#333">Server</text>
+
+  <!-- lifelines -->
+  <line x1="170" y1="40" x2="170" y2="284" stroke="#CCC" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="470" y1="40" x2="470" y2="284" stroke="#CCC" stroke-width="1" stroke-dasharray="3 3"/>
+
+  <!-- initial download -->
+  <line x1="170" y1="72" x2="470" y2="72" stroke="#E58A3C" stroke-width="1.8" marker-end="url(#sArrOrange)"/>
+  <text x="320" y="64" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#B05E1C">GET /api/catalog/public/202601.json</text>
+  <line x1="470" y1="98" x2="170" y2="98" stroke="#E58A3C" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#sArrOrangeOpen)"/>
+  <text x="320" y="90" text-anchor="middle" font-size="10.5" fill="#C6873F">fetches the course data (a 1.21 MB JSON file)</text>
+
+  <!-- local search block centered on browser lifeline -->
+  <rect x="88" y="122" width="164" height="98" rx="7" fill="#E58A3C" fill-opacity="0.10" stroke="#E58A3C" stroke-width="1.4"/>
+  <text x="170" y="142" text-anchor="middle" font-size="10.5" fill="#B05E1C">types &#8220;m&#8221;, &#8220;ma&#8221;, &#8220;mat&#8221;, &#8230;</text>
+  <text x="170" y="161" text-anchor="middle" font-size="10.5" font-weight="600" fill="#B05E1C">debounce 300 ms</text>
+  <text x="170" y="180" text-anchor="middle" font-size="10.5" font-weight="600" fill="#B05E1C">filter 4,449 courses in memory</text>
+  <text x="170" y="199" text-anchor="middle" font-size="10.5" font-weight="600" fill="#B05E1C">render without needing</text>
+  <text x="170" y="213" text-anchor="middle" font-size="10.5" font-weight="600" fill="#B05E1C">any server-side requests</text>
+  <!-- self-loop on right edge of block -->
+  <path d="M 252 152 C 278 156, 278 184, 252 188" fill="none" stroke="#E58A3C" stroke-width="1.6" marker-end="url(#sArrOrange)"/>
+
+  <!-- revalidation an hour later -->
+  <line x1="170" y1="246" x2="470" y2="246" stroke="#E58A3C" stroke-width="1.8" marker-end="url(#sArrOrange)"/>
+  <text x="320" y="238" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#B05E1C">an hour later: GET + If-None-Match</text>
+  <line x1="470" y1="272" x2="170" y2="272" stroke="#E58A3C" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#sArrOrangeOpen)"/>
+  <text x="320" y="264" text-anchor="middle" font-size="10.5" font-family="ui-monospace, Menlo, monospace" fill="#C6873F">304 Not Modified</text>
+
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/stack.svg
+++ b/frontend/public/images/release_notes/shopping-period/stack.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 680 260" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <!-- eyebrow labels -->
+  <text x="96" y="46" text-anchor="end" font-size="10" letter-spacing="1" fill="#999">CLIENT</text>
+  <text x="96" y="94" text-anchor="end" font-size="10" letter-spacing="1" fill="#999">EDGE</text>
+  <text x="96" y="142" text-anchor="end" font-size="10" letter-spacing="1" fill="#999">APP</text>
+  <text x="96" y="190" text-anchor="end" font-size="10" letter-spacing="1" fill="#999">DATA</text>
+  <text x="96" y="238" text-anchor="end" font-size="10" letter-spacing="1" fill="#999">PIPELINE</text>
+
+  <!-- client -->
+  <rect x="110" y="24" width="550" height="36" rx="7" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="385" y="46" text-anchor="middle" font-size="11.5" fill="#333"><tspan font-weight="600">React SPA</tspan> &#183; Vite &#183; static assets on Cloudflare Pages</text>
+
+  <!-- edge -->
+  <rect x="110" y="72" width="550" height="36" rx="7" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="385" y="94" text-anchor="middle" font-size="11.5" fill="#333"><tspan font-weight="600">Traefik</tspan> &#183; TLS termination, reverse proxy</text>
+
+  <!-- app -->
+  <rect x="110" y="120" width="300" height="36" rx="7" fill="#E58A3C" fill-opacity="0.10" stroke="#E58A3C" stroke-width="1.4"/>
+  <text x="260" y="142" text-anchor="middle" font-size="11.5" fill="#7A4A17"><tspan font-weight="600">Express API</tspan> &#183; Node, Docker &#183; static catalog</text>
+  <rect x="430" y="120" width="230" height="36" rx="7" fill="#4A7BB5" fill-opacity="0.10" stroke="#4A7BB5" stroke-width="1.4"/>
+  <text x="545" y="142" text-anchor="middle" font-size="11.5" fill="#2F5787"><tspan font-weight="600">Hasura</tspan> &#183; GraphQL engine</text>
+
+  <!-- data -->
+  <rect x="110" y="168" width="300" height="36" rx="7" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="260" y="190" text-anchor="middle" font-size="11.5" fill="#333"><tspan font-weight="600">Postgres</tspan> &#183; course DB + user DB</text>
+  <rect x="430" y="168" width="230" height="36" rx="7" fill="none" stroke="#444" stroke-width="1.5"/>
+  <text x="545" y="190" text-anchor="middle" font-size="11.5" fill="#333"><tspan font-weight="600">Redis</tspan> &#183; sessions</text>
+
+  <!-- pipeline -->
+  <rect x="110" y="216" width="550" height="36" rx="7" fill="none" stroke="#999" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="385" y="238" text-anchor="middle" font-size="11.5" fill="#666"><tspan font-weight="600">Ferry</tspan> &#183; Python crawler on GitHub Actions &#183; nightly, writes the course DB</text>
+
+  <!-- single-box bracket: edge through data run on one server -->
+  <line x1="668" y1="72" x2="668" y2="204" stroke="#BBB" stroke-width="1.5"/>
+  <line x1="662" y1="72" x2="668" y2="72" stroke="#BBB" stroke-width="1.5"/>
+  <line x1="662" y1="204" x2="668" y2="204" stroke="#BBB" stroke-width="1.5"/>
+  <text x="676" y="141" font-size="10" fill="#999" transform="rotate(90 676 141)" text-anchor="middle">one server</text>
+</svg>

--- a/frontend/public/images/release_notes/shopping-period/stats.svg
+++ b/frontend/public/images/release_notes/shopping-period/stats.svg
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 680 130" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="100%" height="100%" rx="12" fill="#FDFDFC"/>
+  <line x1="136" y1="30" x2="136" y2="100" stroke="#E5E5E5" stroke-width="1.5"/>
+  <line x1="272" y1="30" x2="272" y2="100" stroke="#E5E5E5" stroke-width="1.5"/>
+  <line x1="408" y1="30" x2="408" y2="100" stroke="#E5E5E5" stroke-width="1.5"/>
+  <line x1="544" y1="30" x2="544" y2="100" stroke="#E5E5E5" stroke-width="1.5"/>
+
+  <text x="68" y="60" text-anchor="middle" font-size="27" font-weight="700" fill="#E58A3C">21M+</text>
+  <text x="68" y="84" text-anchor="middle" font-size="10.5" fill="#666">requests</text>
+  <text x="68" y="98" text-anchor="middle" font-size="10.5" fill="#666">per month</text>
+
+  <text x="204" y="60" text-anchor="middle" font-size="27" font-weight="700" fill="#E58A3C">6,500+</text>
+  <text x="204" y="84" text-anchor="middle" font-size="10.5" fill="#666">undergraduates</text>
+  <text x="204" y="98" text-anchor="middle" font-size="10.5" fill="#666">served</text>
+
+  <text x="340" y="60" text-anchor="middle" font-size="27" font-weight="700" fill="#E58A3C">4,449</text>
+  <text x="340" y="84" text-anchor="middle" font-size="10.5" fill="#666">courses</text>
+  <text x="340" y="98" text-anchor="middle" font-size="10.5" fill="#666">this semester</text>
+
+  <text x="476" y="60" text-anchor="middle" font-size="27" font-weight="700" fill="#E58A3C">1.21 MB</text>
+  <text x="476" y="84" text-anchor="middle" font-size="10.5" fill="#666">gzipped catalog</text>
+  <text x="476" y="98" text-anchor="middle" font-size="10.5" fill="#666">payload</text>
+
+  <text x="612" y="60" text-anchor="middle" font-size="27" font-weight="700" fill="#E58A3C">1</text>
+  <text x="612" y="84" text-anchor="middle" font-size="10.5" fill="#666">self-managed</text>
+  <text x="612" y="98" text-anchor="middle" font-size="10.5" fill="#666">server</text>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,9 @@ const Fall24Release = suspended(() => import('./pages/releases/fall24.mdx'));
 const Spring26Release = suspended(
   () => import('./pages/releases/spring26.mdx'),
 );
+const ShoppingPeriod = suspended(
+  () => import('./pages/releases/shopping-period.mdx'),
+);
 
 function Modal() {
   const currentModal = useStore((state) => state.currentModal);
@@ -192,6 +195,7 @@ function App() {
         <Route path="/releases/spring24" element={<Spring24Release />} />
         <Route path="/releases/fall24" element={<Fall24Release />} />
         <Route path="/releases/spring26" element={<Spring26Release />} />
+        <Route path="/releases/shopping-period" element={<ShoppingPeriod />} />
         <Route path="/releases" element={<ReleaseNotes />} />
         {/* Catch-all route to NotFound page */}
         <Route path="/*" element={<NotFound />} />

--- a/frontend/src/components/markdown/Layout.module.css
+++ b/frontend/src/components/markdown/Layout.module.css
@@ -36,6 +36,17 @@
   display: inline-block;
 }
 
+.container figure {
+  margin: 1.5rem 0;
+}
+
+.container figcaption {
+  margin-top: 0.5rem;
+  text-align: center;
+  font-size: small;
+  color: var(--color-text-tertiary);
+}
+
 .container blockquote {
   margin-left: 1em;
   padding-left: 1em;

--- a/frontend/src/pages/releases/releases.tsx
+++ b/frontend/src/pages/releases/releases.tsx
@@ -12,6 +12,13 @@ type ReleaseNote = {
 const releaseNotes: ReleaseNote[] = [
   // Add more releases below
   {
+    title: 'Surviving Shopping Period',
+    summary:
+      "A high-level tour of CourseTable's architecture and how we keep the site alive during peak traffic.",
+    path: '/releases/shopping-period',
+    date: '2026-07-11',
+  },
+  {
     title: '2025 + Spring 2026 Release',
     summary:
       'Discover the latest features and improvements in our 2025 + Spring 2026 update.',

--- a/frontend/src/pages/releases/shopping-period.mdx
+++ b/frontend/src/pages/releases/shopping-period.mdx
@@ -1,0 +1,150 @@
+# How CourseTable Survives Shopping Period
+
+_2026-07-11_
+
+[CourseTable](/) is a student-run course discovery platform that allows Yale students to view course evaluations, build class schedules, and compare them with friends. Nearly all of Yale's 6,500+ undergraduates use the tool, and it serves 21M+ requests a month at peak. The site is built and operated entirely by a team of student volunteers, and our code is [open source](https://github.com/coursetable/coursetable).
+
+In this article, I'll give a high-level overview of our architecture, and explain how we keep the site alive during peak traffic.
+
+## Shopping period
+
+Every semester, Yale has a _shopping period_: a few days where students begin picking courses for the next term. During shopping period, nearly every undergrad opens CourseTable at once to search for courses, read evaluations, and build worksheets. This is when CourseTable faces the biggest load, and also an inconvenient time for us to be firefighting (since we want to plan our courses too). In addition, we have no autoscaling, no on-call rotation, and only utilize one self-managed server, which means our architectural choices are especially important.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/stats.svg"
+    alt="Key statistics: 21M+ requests per month, 6,500+ undergraduates served, 4,449 courses this semester, a 1.21 MB gzipped catalog payload, and one self-managed server"
+    width={680}
+  />
+  <figcaption>Statistics regarding recent CourseTable traffic.</figcaption>
+</figure>
+
+## The tech stack
+
+At its core, our frontend is a React SPA (single page application) built with Vite and statically served with Cloudflare Pages. Cloudflare also sits in front of our API, where we use its redirect rules to serve custom link previews to crawler bots (as covered in [a previous post](/releases/link-preview)). Everything else lives on a self-managed box behind Traefik, including our Express API in Docker, our Hasura instance exposing the course database as GraphQL, our two Postgres databases for course and user data, and our Redis store for sessions. The course data itself is produced by [Ferry](https://github.com/coursetable/ferry), a separate Python crawler that runs on GitHub Actions.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/stack.svg"
+    alt="CourseTable's stack in layers: a React SPA on Cloudflare Pages; Traefik as the edge proxy; an Express API in Docker alongside Hasura; Postgres with separate course and user databases plus Redis for sessions; and Ferry, a Python crawler on GitHub Actions, as the data pipeline"
+    width={680}
+  />
+  <figcaption>
+    Visualizing our tech stack. Everything below the client layer runs on a
+    single self-managed server, and Ferry runs offline on GitHub Actions.
+  </figcaption>
+</figure>
+
+## A basic architecture
+
+The easiest way to serve our course catalog is to build a search endpoint where the browser sends the query and filters, the server translates them into SQL, and the database returns a page of results. Most catalog sites initially work this way.
+
+But if we use such an architecture in shopping period, the thousands of students searching simultaneously will overload our backend. Since search is interactive, each user produces a stream of requests as they type, toggle filters, and re-sort, and every one of those requests becomes a database query on our singular machine.
+
+A standard fix here might involve horizontal scaling with a load balancer, or implementing a search cluster, or even utilizing read replicas. However, we want to minimize the need for unnecessary infrastructure, since it's expensive, and more importantly, maintaining it requires a lot of effort.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/naive-search.svg"
+    alt="The conventional search architecture: many browsers each send a GET /search request per keystroke to the server, which runs a SQL query against the database for every one, putting the database on the hot path"
+    width={640}
+  />
+  <figcaption>
+    A basic design, where every keystroke from every student becomes a database
+    query. This easily overwhelms a single machine.
+  </figcaption>
+</figure>
+
+## Design optimizations
+
+First, when taking a closer look at our data, we find that it's actually quite small. Semesters only have a few thousand courses: the current one has 4,449, and treating cross-listed courses as duplicates (e.g., a class offered as both MATH 101 and STAT 101 counts twice) gets us to 5,937 total course listings. This is only 6.2 MB of JSON, and 1.2 MB when gzipped. In addition to being small, this data is public, because every student sees the same catalog. Finally, it's read-mostly: in the average day, a course's metadata might only be written to a few times, but could receive millions of reads.
+
+### Keeping the catalog static
+
+Now, since our data is small, public, and read-mostly, we don't need to query a database on every request. Instead, we can pre-generate each semester's entire catalog as one JSON file and serve it with a one-hour cache lifetime. When a user opens the catalog, their browser downloads the semester once, and for the next hour, it only checks whether the file changed. Since our evaluation data is gated behind an eligibility check, we ship it as a second, auth-gated file (which is 148 KB gzipped), and allow the client to merge it into our pre-existing course objects. Together, these allow us to serve our catalog without GraphQL or SQL.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/architecture.svg"
+    alt="CourseTable architecture: a hot path where the browser fetches static catalog JSON from the API server, a live path where the browser queries Hasura and Postgres through a proxy for course details, and an offline path where the Ferry crawler ingests Yale data nightly and triggers a rewrite of the static files"
+    width={680}
+  />
+  <figcaption>
+    Our three paths. During shopping period, the orange one is most active.
+  </figcaption>
+</figure>
+
+### Searching in the browser
+
+Once a semester's data is downloaded, we execute all searches for it through the client. _This means there is no server-side course-search endpoint, meaning there is nothing to scale, because peak search traffic produces exactly zero requests._ Searching across multiple semesters then just means fetching more static files, each of which is cached independently. Of course, since searches run on the browser's main thread, expensive queries are slightly slower on old laptops than server-side searches would be. But the large majority of queries don't have enough filters to trigger these issues, making the tradeoff worth it.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/search-flow.svg"
+    alt="Sequence diagram of CourseTable's search: the browser fetches the course data (a 1.21 MB JSON file) once, then every keystroke is debounced 300 ms and filters 4,449 courses in memory, rendering without any server-side requests"
+    width={640}
+  />
+  <figcaption>The full lifecycle of a search session.</figcaption>
+</figure>
+
+### Keeping the payload small
+
+At this point, our design is fully dependent on the size of our static course files. For this reason, we try to keep the payload as small as possible. For each course, we only carry the 24 fields that are essential to rendering the catalog view, and defer everything else to a live query when a course is opened.
+
+Originally, we keyed this file by _listing_, which duplicated all of a course's data per cross-listing. Rekeying by _course_ deduplicated all that data in exchange for a single extra lookup when rendering: the client now stores each course once, and has listings point to it by ID. We're careful to keep this schema minimal, as it's the backbone behind our efficient search.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/payload-rekeying.svg"
+    alt="Before and after of the payload schema: keyed by listing, MATH 101 and STAT 101 each store a full copy of the same course data; keyed by course, one course object is stored once and both listings point to it by ID"
+    width={680}
+  />
+  <figcaption>
+    Rekeying our payloads so that cross-listings share course objects.
+  </figcaption>
+</figure>
+
+### Serving the tail via GraphQL
+
+Above, I described how we only statically carry the fields that are essential to the catalog view. But when we click on a course's modal, we need to view its full description, past offerings of the same course, professor history, and various other info. This data is the long tail: it's far rarer than catalog browsing, and it needs data our static payload deliberately omits. To fetch it, queries go through a thin proxy to [Hasura](https://hasura.io), which compiles a nested GraphQL query into a single SQL statement with joins. That way, our live path only costs one database round-trip, rather than the [N+1 issue](https://www.apollographql.com/docs/graphos/schema-design/guides/handling-n-plus-one) which hand-written resolvers tend to produce. Essentially, we're making the bet that users will scroll through a catalog a lot more than they'll click on random courses.
+
+### Refreshing data at 3 AM
+
+As mentioned previously, the course data is owned by Ferry. Every night around 3 AM, a GitHub action triggers Ferry to pull from Yale's course API and the evaluations system, reconcile cross-listings, and write to Postgres. The action then pings our API server's refresh endpoint with the semesters that actually changed, after which our server re-queries Hasura and rewrites the relevant static files in the background.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/refresh-pipeline.svg"
+    alt="The nightly refresh pipeline: a GitHub Action fires around 3 AM, Ferry crawls Yale's APIs, writes course data to Postgres, pings the refresh endpoint with the changed semesters, and the server rewrites the static files"
+    width={680}
+  />
+  <figcaption>The nightly offline refresh to keep our data recent.</figcaption>
+</figure>
+
+Since Yale focuses its updates on recent classes, we only need to regenerate data for the four latest semesters. Everything older than that was already generated in a backfill, and sits on disk as static files. It's extremely rare for Yale to edit prehistoric courses, but if they do, our refresh endpoint allows us to regenerate semesters manually.
+
+### Handling user data
+
+Finally, the last thing our server has to do during shopping period is handle user data (e.g., logins, friends, profiles). These are just small authenticated reads and writes against our user database, but since the catalog path is static, this is where we feel most of our load. Nevertheless, we don't do anything special here, and just follow standard system design practices, like batching writes and deduplicating requests that are being processed. This is because user data traffic is a small fraction of what our non-optimized catalog would have generated, so we don't worry about it too much.
+
+## Benchmarking
+
+To see how our optimized design compares to a naive one, we load-tested both against our dev stack. When simulating a shopping period, we found that a naive endpoint peaks at ~650 requests per second while pinning most of our Postgres cores, supporting only ~130 simultaneous searchers at 5 keystrokes per search (about 2% of our users). Our static design, on the other hand, keeps the database fully idle, supporting the full system load with ease.
+
+<figure>
+  <img
+    src="/images/release_notes/shopping-period/benchmark.svg"
+    alt="Plot of p99 latency versus concurrent connections: the naive search API's latency climbs steadily, crossing one second past 250 connections and approaching two seconds at 500, while the static catalog path stays nearly flat, peaking at 103 ms"
+    width={680}
+  />
+  <figcaption>
+    Measured p99 latency under load. Our optimized design handles shopping
+    period with ease when compared to a naive implementation.
+  </figcaption>
+</figure>
+
+## Conclusion
+
+Thanks to our modifications, CourseTable is now able to ignore the problem of serving large concurrent loads. Instead, since our data is small, public, and read-mostly, we can utilize precomputation, periodic fetching, and browser-fueled searches to our advantage. And if there's a moral to this story, it's that your search bar might not always need a backend.
+
+_This post is crossposted from [aryansharma.com](https://www.aryansharma.com/blog/coursetable)._


### PR DESCRIPTION
Crossposts Aryan Sharma's CourseTable architecture write-up (originally published at [aryansharma.com/blog/coursetable](https://www.aryansharma.com/blog/coursetable)) to the team releases blog, per Reyansh's request. The content is ported faithfully — only the format is adapted to our MDX conventions, and the 8 figure SVGs each get a light-card background so their dark text stays legible under the site's dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Surviving Shopping Period” release note, with details on performance, scalability, data freshness, and user data handling during peak traffic.
  * Added a dedicated page at `/releases/shopping-period`.
  * Improved formatting for figures and captions in release articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->