### PR TITLE
docs: tighten wording in shopping-period blog post

### DIFF
--- a/frontend/src/pages/releases/shopping-period.mdx
+++ b/frontend/src/pages/releases/shopping-period.mdx
@@ -8,7 +8,7 @@ In this article, I'll give a high-level overview of our architecture, and explai
 
 ## Shopping period
 
-Every semester, Yale has a _shopping period_: a few days where students begin picking courses for the next term. During shopping period, nearly every undergrad opens CourseTable at once to search for courses, read evaluations, and build worksheets. This is when CourseTable faces the biggest load, and also an inconvenient time for us to be firefighting (since we want to plan our courses too). In addition, we have no autoscaling, no on-call rotation, and only utilize one self-managed server, which means our architectural choices are especially important.
+Every semester, Yale has a _shopping period_: a few days where students begin picking courses for the next term. During shopping period, nearly every undergrad opens CourseTable at once to search for courses, read evaluations, and build worksheets. This is when CourseTable faces the biggest load, and also an inconvenient time for us to be firefighting (since we want to plan our courses too). In addition, we have no autoscaling, no on-call rotation, and only use one self-managed server, which means our architectural choices are especially important.
 
 <figure>
   <img
@@ -76,7 +76,7 @@ Now, since our data is small, public, and read-mostly, we don't need to query a 
 
 ### Searching in the browser
 
-Once a semester's data is downloaded, we execute all searches for it through the client. _This means there is no server-side course-search endpoint, meaning there is nothing to scale, because peak search traffic produces exactly zero requests._ Searching across multiple semesters then just means fetching more static files, each of which is cached independently. Of course, since searches run on the browser's main thread, expensive queries are slightly slower on old laptops than server-side searches would be. But the large majority of queries don't have enough filters to trigger these issues, making the tradeoff worth it.
+Once a semester's data is downloaded, we execute all searches for it through the client. Searching across multiple semesters then just means fetching more static files, each of which is cached independently. Of course, since searches run on the browser's main thread, expensive queries are slightly slower on old laptops than server-side searches would be. But the large majority of queries don't have enough filters to trigger these issues, making the tradeoff worth it.
 
 <figure>
   <img


### PR DESCRIPTION
Small copy edits to the "How CourseTable Survives Shopping Period" blog post (`frontend/src/pages/releases/shopping-period.mdx`):

- Removed the sentence "_This means there is no server-side course-search endpoint, meaning there is nothing to scale, because peak search traffic produces exactly zero requests._" — it was redundant with the surrounding paragraph.
- Changed "only utilize one self-managed server" → "only use one self-managed server".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified wording about infrastructure constraints during shopping period.
  * Updated the browser-search section by removing an outdated claim while retaining information about client-side searching, caching, and performance tradeoffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->