### PR TITLE
fix: don't count hidden worksheet courses as schedule conflicts

### DIFF
--- a/frontend/src/utilities/course.ts
+++ b/frontend/src/utilities/course.ts
@@ -124,7 +124,8 @@ export function checkConflict(
 ): CatalogListing[] {
   const conflicts: CatalogListing[] = [];
   if (!listing.course.course_meetings.length) return conflicts;
-  loopWorksheet: for (const { listing: worksheetCourse } of worksheetData) {
+  loopWorksheet: for (const { listing: worksheetCourse, hidden } of worksheetData) {
+    if (hidden) continue;
     if (worksheetCourse.course.season_code !== listing.course.season_code)
       continue;
     for (const meeting1 of worksheetCourse.course.course_meetings) {

--- a/frontend/src/utilities/course.ts
+++ b/frontend/src/utilities/course.ts
@@ -124,7 +124,10 @@ export function checkConflict(
 ): CatalogListing[] {
   const conflicts: CatalogListing[] = [];
   if (!listing.course.course_meetings.length) return conflicts;
-  loopWorksheet: for (const { listing: worksheetCourse, hidden } of worksheetData) {
+  loopWorksheet: for (const {
+    listing: worksheetCourse,
+    hidden,
+  } of worksheetData) {
     if (hidden) continue;
     if (worksheetCourse.course.season_code !== listing.course.season_code)
       continue;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

The template can be skipped for small and straightforward changes, such as typo fixes.
-->

## Pre-flight checklist

- [] I have searched for potential duplicate pull requests.
- [] **If this is a code change**: I have written unit tests and/or conducted manual tests to fully verify the new behavior.
- [] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Summary

This PR fixes the following bug:
- The "hide courses with conflicting times" catalog filter (and the conflict
  warning icon in the worksheet toggle button) treats **all** courses in
  the worksheet as conflict sources — including courses the user has
  hidden/greyed out from their calendar. This means a catalog course can
  get hidden by the filter even though it doesn't actually overlap with
  anything visibly on the schedule.

Fix: `checkConflict` now skips worksheet courses where `hidden` is true,
since those aren't displayed on the calendar and shouldn't block otherwise
non-conflicting catalog courses.

## Test plan (required)

No automated test currently exists for `checkConflict` (there's no test
file for `utilities/course.ts` at all). I didn't run the full local dev
environment, but just traced the logic
manually against the `WorksheetCourse` type, which already exposes
`hidden: boolean | null`. I'm more than happy to add a unit test or verify against a
running instance, but I think the change is reasonable simply on it's own. I'm not on the CourseTable FWIW, just noticed this.

<!-- Make sure tests pass on both Travis and Circle CI. -->

## Related issues/PRs
Nothing related. Honestly a pretty simple and self-contained fix.

<!-- Put `fixes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conflict detection now ignores hidden worksheet courses, preventing them from being incorrectly reported as schedule conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->