### PR TITLE
fix: handle concurrent worksheet course adds

### DIFF
--- a/api/src/user/user.handlers.ts
+++ b/api/src/user/user.handlers.ts
@@ -97,12 +97,21 @@ async function updateWorksheetCourse(
 
   if (action === 'add') {
     if (existing) return 'ALREADY_BOOKMARKED';
-    await db.insert(worksheetCourses).values({
-      worksheetId: existingMeta.id,
-      crn,
-      color,
-      hidden,
-    });
+    // Concurrent double-adds can both pass the existence check above; treat
+    // unique conflicts as the same already-bookmarked outcome.
+    const [created] = await db
+      .insert(worksheetCourses)
+      .values({
+        worksheetId: existingMeta.id,
+        crn,
+        color,
+        hidden,
+      })
+      .onConflictDoNothing({
+        target: [worksheetCourses.worksheetId, worksheetCourses.crn],
+      })
+      .returning({ id: worksheetCourses.id });
+    if (!created) return 'ALREADY_BOOKMARKED';
   } else if (action === 'remove') {
     if (!existing) return 'NOT_BOOKMARKED';
     await db

--- a/frontend/src/queries/api.ts
+++ b/frontend/src/queries/api.ts
@@ -274,7 +274,16 @@ export async function updateWorksheetCourses(
   const request = (
     payload: UpdateWorksheetCourseAction | UpdateWorksheetCourseAction[],
   ) => {
-    const key = JSON.stringify(payload);
+    // Ignore randomly chosen add colors so rapid double-clicks coalesce.
+    // Keep color for update actions where it is intentional.
+    const normalize = (item: UpdateWorksheetCourseAction) => {
+      if (item.action !== 'add') return item;
+      const { color: _color, ...rest } = item;
+      return rest;
+    };
+    const key = JSON.stringify(
+      Array.isArray(payload) ? payload.map(normalize) : normalize(payload),
+    );
     const existing = inflightWorksheetUpdates.get(key);
     if (existing) return existing;
     const pending = requestInternal(payload).finally(() =>


### PR DESCRIPTION
## Summary
- Treat unique-constraint races on worksheet course add as `ALREADY_BOOKMARKED` instead of a 500/`PostgresError`.
- Coalesce in-flight add requests that only differ by randomly chosen color so double-clicks share one request.

Fixes FRONTEND-6QF.

## Test plan
- [ ] Add a course to worksheet normally
- [ ] Rapidly double-click add and confirm no PostgresError toast / Sentry noise
- [ ] Changing course color still works as its own update