### PR TITLE
chore: add project-scoped sentry mcp configs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.sentry]
+url = "https://mcp.sentry.dev/mcp"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "sentry": {
+      "enabled": true
+    }
+  }
+}

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,7 +1,0 @@
-{
-  "plugins": {
-    "sentry": {
-      "enabled": true
-    }
-  }
-}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add Coursetable-only Sentry MCP config for Cursor, Claude Code, and Codex so the team can triage production errors from agents without installing Sentry globally.

## Test plan
- [ ] Open this repo in Cursor / Claude Code / Codex and confirm Sentry MCP appears
- [ ] Authenticate once per agent if prompted
- [ ] Confirm other repos do not pick up Sentry unless configured separately